### PR TITLE
feat(logic,models): pitch-detection core + domain types

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -5,5 +5,11 @@ module.exports = {
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '^.+\\.(ts|tsx)?$': 'ts-jest'
-  }
+  },
+  // The default react-native preset only transpiles react-native itself; RN
+  // community modules ship untranspiled ESM, so whitelist the ones we use
+  // (e.g. react-native-config) for transformation.
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|react-native-config)/)'
+  ]
 };

--- a/packages/logic/src/__tests__/index.test.ts
+++ b/packages/logic/src/__tests__/index.test.ts
@@ -1,7 +1,10 @@
-import { test } from '../index';
+import * as logic from '../index';
 
-describe('test', () => {
-  it('works', () => {
-    expect(test).toEqual('test');
+describe('logic public API', () => {
+  it('exposes pitch detection and note helpers', () => {
+    expect(typeof logic.detectPitch).toBe('function');
+    expect(typeof logic.frequencyToNote).toBe('function');
+    expect(typeof logic.frequencyToMidi).toBe('function');
+    expect(typeof logic.midiToFrequency).toBe('function');
   });
 });

--- a/packages/logic/src/__tests__/mpm.test.ts
+++ b/packages/logic/src/__tests__/mpm.test.ts
@@ -1,0 +1,41 @@
+import { detectPitch } from '../mpm';
+
+const SAMPLE_RATE = 44100;
+
+function sine(frequencyHz: number, length: number): Float32Array {
+  const out = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    out[i] = Math.sin((2 * Math.PI * frequencyHz * i) / SAMPLE_RATE);
+  }
+  return out;
+}
+
+describe('detectPitch (MPM)', () => {
+  [110, 220, 440, 660].forEach((freq) => {
+    it(`detects a ${freq}Hz sine within 1%`, () => {
+      const { frequency, clarity } = detectPitch(sine(freq, 2048), SAMPLE_RATE);
+      expect(frequency).not.toBeNull();
+      expect(Math.abs((frequency as number) - freq) / freq).toBeLessThan(0.01);
+      expect(clarity).toBeGreaterThan(0.85);
+    });
+  });
+
+  it('returns null for silence', () => {
+    const { frequency } = detectPitch(new Float32Array(2048), SAMPLE_RATE);
+    expect(frequency).toBeNull();
+  });
+
+  it('honours the maxFrequency bound', () => {
+    const { frequency } = detectPitch(sine(440, 2048), SAMPLE_RATE, {
+      maxFrequency: 200
+    });
+    expect(frequency).toBeNull();
+  });
+
+  it('honours the minFrequency bound', () => {
+    const { frequency } = detectPitch(sine(110, 2048), SAMPLE_RATE, {
+      minFrequency: 200
+    });
+    expect(frequency).toBeNull();
+  });
+});

--- a/packages/logic/src/__tests__/notes.test.ts
+++ b/packages/logic/src/__tests__/notes.test.ts
@@ -1,0 +1,40 @@
+import {
+  frequencyToMidi,
+  frequencyToNote,
+  midiToFrequency
+} from '../notes';
+
+describe('note conversions', () => {
+  it('maps A4 (440Hz) to MIDI 69 / A4', () => {
+    expect(Math.round(frequencyToMidi(440))).toBe(69);
+    const note = frequencyToNote(440);
+    expect(note.midi).toBe(69);
+    expect(note.name).toBe('A');
+    expect(note.octave).toBe(4);
+    expect(Math.abs(note.cents)).toBeLessThanOrEqual(1);
+  });
+
+  it('maps middle C (~261.63Hz) to MIDI 60 / C4', () => {
+    const note = frequencyToNote(261.6256);
+    expect(note.midi).toBe(60);
+    expect(note.name).toBe('C');
+    expect(note.octave).toBe(4);
+  });
+
+  it('round-trips midi <-> frequency', () => {
+    expect(midiToFrequency(69)).toBeCloseTo(440, 5);
+    expect(midiToFrequency(60)).toBeCloseTo(261.6256, 2);
+  });
+
+  it('reports positive cents for a slightly sharp A4', () => {
+    const note = frequencyToNote(443);
+    expect(note.midi).toBe(69);
+    expect(note.cents).toBeGreaterThan(0);
+  });
+
+  it('reports negative cents for a slightly flat A4', () => {
+    const note = frequencyToNote(437);
+    expect(note.midi).toBe(69);
+    expect(note.cents).toBeLessThan(0);
+  });
+});

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -1,1 +1,2 @@
-export const test = 'test';
+export * from './mpm';
+export * from './notes';

--- a/packages/logic/src/mpm.ts
+++ b/packages/logic/src/mpm.ts
@@ -1,0 +1,154 @@
+/**
+ * Monophonic pitch detection via the McLeod Pitch Method (MPM).
+ *
+ * MPM is well suited to singing: it computes the Normalized Square Difference
+ * Function (NSDF) and picks the first "key maximum" above a clarity threshold,
+ * which is robust to the strong harmonics of the human voice. The NSDF peak
+ * value doubles as a clarity/confidence score (the "vocal clarity" metric the
+ * product surfaces).
+ *
+ * This is a pure function over a frame of PCM samples — no audio-engine or RN
+ * dependencies — so it runs unchanged in Jest, in a worklet, or (ported) in
+ * C++ later.
+ */
+
+export interface PitchResult {
+  /** Detected fundamental frequency in Hz, or null if none was confident. */
+  frequency: number | null;
+  /** NSDF clarity at the chosen peak, in [0, 1]. */
+  clarity: number;
+}
+
+export interface MpmOptions {
+  /**
+   * Fraction (0..1) of the highest NSDF peak a key maximum must reach to be
+   * accepted. Higher = stricter. Default 0.9.
+   */
+  clarityThreshold?: number;
+  /** Reject detections below this frequency (Hz). */
+  minFrequency?: number;
+  /** Reject detections above this frequency (Hz). */
+  maxFrequency?: number;
+}
+
+const EMPTY: PitchResult = { frequency: null, clarity: 0 };
+
+export function detectPitch(
+  samples: Float32Array,
+  sampleRate: number,
+  options: MpmOptions = {}
+): PitchResult {
+  const threshold = options.clarityThreshold ?? 0.9;
+  const n = samples.length;
+  if (n < 4 || sampleRate <= 0) {
+    return EMPTY;
+  }
+
+  // Normalized Square Difference Function (NSDF), type-II autocorrelation.
+  const nsdf = new Float32Array(n);
+  for (let tau = 0; tau < n; tau++) {
+    let acf = 0; // autocorrelation at lag tau
+    let div = 0; // sum of squares of both windows (m'(tau))
+    for (let i = 0; i < n - tau; i++) {
+      const a = samples[i];
+      const b = samples[i + tau];
+      acf += a * b;
+      div += a * a + b * b;
+    }
+    nsdf[tau] = div > 0 ? (2 * acf) / div : 0;
+  }
+
+  // Collect the maximum of each positive "hump" after the lag-0 lobe.
+  const maxPositions: number[] = [];
+  let i = 0;
+  // Skip the initial positive lobe around lag 0.
+  while (i < n - 1 && nsdf[i] > 0) {
+    i++;
+  }
+  while (i < n - 1) {
+    // Advance to the next positive region.
+    while (i < n - 1 && nsdf[i] <= 0) {
+      i++;
+    }
+    if (i >= n - 1) {
+      break;
+    }
+    // Track the local maximum within this positive region.
+    let localMax = -Infinity;
+    let localMaxIdx = i;
+    while (i < n - 1 && nsdf[i] > 0) {
+      if (nsdf[i] > localMax) {
+        localMax = nsdf[i];
+        localMaxIdx = i;
+      }
+      i++;
+    }
+    maxPositions.push(localMaxIdx);
+  }
+
+  if (maxPositions.length === 0) {
+    return EMPTY;
+  }
+
+  // Highest peak sets the acceptance cutoff.
+  let highest = 0;
+  for (let k = 0; k < maxPositions.length; k++) {
+    const v = nsdf[maxPositions[k]];
+    if (v > highest) {
+      highest = v;
+    }
+  }
+  if (highest <= 0) {
+    return EMPTY;
+  }
+
+  const cutoff = threshold * highest;
+
+  // First key maximum at or above the cutoff wins.
+  for (let k = 0; k < maxPositions.length; k++) {
+    const p = maxPositions[k];
+    if (nsdf[p] < cutoff) {
+      continue;
+    }
+
+    // Parabolic interpolation around the integer peak for sub-sample accuracy.
+    let peakTau = p;
+    let peakValue = nsdf[p];
+    if (p > 0 && p < n - 1) {
+      const s0 = nsdf[p - 1];
+      const s1 = nsdf[p];
+      const s2 = nsdf[p + 1];
+      const denom = s0 + s2 - 2 * s1;
+      if (denom !== 0) {
+        const delta = (0.5 * (s0 - s2)) / denom;
+        peakTau = p + delta;
+        peakValue = s1 - 0.25 * (s0 - s2) * delta;
+      }
+    }
+
+    if (peakTau <= 0) {
+      return { frequency: null, clarity: clamp01(peakValue) };
+    }
+
+    const frequency = sampleRate / peakTau;
+    if (options.minFrequency != null && frequency < options.minFrequency) {
+      return { frequency: null, clarity: clamp01(peakValue) };
+    }
+    if (options.maxFrequency != null && frequency > options.maxFrequency) {
+      return { frequency: null, clarity: clamp01(peakValue) };
+    }
+    return { frequency, clarity: clamp01(peakValue) };
+  }
+
+  return { frequency: null, clarity: clamp01(highest) };
+}
+
+function clamp01(value: number): number {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}

--- a/packages/logic/src/notes.ts
+++ b/packages/logic/src/notes.ts
@@ -1,0 +1,59 @@
+/**
+ * Pitch <-> note conversions.
+ *
+ * Pure, dependency-free math so the same code runs in Jest, in an audio
+ * worklet, or on the server. Uses ES5-safe operations (no `**` / Math.log2)
+ * to stay portable across the monorepo's tsconfig targets.
+ */
+
+export const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B'
+] as const;
+
+export type NoteName = (typeof NOTE_NAMES)[number];
+
+export const A4_HZ = 440;
+export const A4_MIDI = 69;
+
+/** Fractional MIDI note number for a frequency (A4/440Hz -> 69). */
+export function frequencyToMidi(frequencyHz: number): number {
+  return A4_MIDI + 12 * (Math.log(frequencyHz / A4_HZ) / Math.LN2);
+}
+
+/** Reference frequency in Hz for a (possibly fractional) MIDI note number. */
+export function midiToFrequency(midi: number): number {
+  return A4_HZ * Math.pow(2, (midi - A4_MIDI) / 12);
+}
+
+export interface NoteReading {
+  /** Nearest MIDI note number. */
+  midi: number;
+  /** Chromatic name of the nearest note. */
+  name: NoteName;
+  /** Scientific-pitch octave. */
+  octave: number;
+  /** Signed cents away from the nearest note, −50..+50. */
+  cents: number;
+}
+
+/** Resolve a frequency to its nearest note plus cents deviation. */
+export function frequencyToNote(frequencyHz: number): NoteReading {
+  const midiFloat = frequencyToMidi(frequencyHz);
+  const midi = Math.round(midiFloat);
+  const cents = Math.round((midiFloat - midi) * 100);
+  const index = ((midi % 12) + 12) % 12;
+  const name = NOTE_NAMES[index];
+  const octave = Math.floor(midi / 12) - 1;
+  return { midi, name, octave, cents };
+}

--- a/packages/models/src/__tests__/index.test.ts
+++ b/packages/models/src/__tests__/index.test.ts
@@ -1,7 +1,9 @@
-import { test } from '../index';
+import { NOTE_NAMES } from '../index';
 
-describe('test', () => {
-  it('works', () => {
-    expect(test).toEqual('test');
+describe('NOTE_NAMES', () => {
+  it('has 12 chromatic names starting at C', () => {
+    expect(NOTE_NAMES).toHaveLength(12);
+    expect(NOTE_NAMES[0]).toBe('C');
+    expect(NOTE_NAMES[9]).toBe('A');
   });
 });

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,1 +1,2 @@
-export const test = 'test';
+export * from './pitch';
+export * from './recording';

--- a/packages/models/src/pitch.ts
+++ b/packages/models/src/pitch.ts
@@ -1,0 +1,55 @@
+/**
+ * Core pitch/note domain types shared across micdrp.
+ *
+ * These are intentionally framework-agnostic (no React Native / audio-engine
+ * imports) so they can be used from the client, a worklet, the server, or
+ * tests without pulling in native dependencies.
+ */
+
+/** The twelve chromatic note names, indexed so that `NOTE_NAMES[0] === 'C'`. */
+export const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B'
+] as const;
+
+export type NoteName = (typeof NOTE_NAMES)[number];
+
+/** A musical note resolved from a frequency. */
+export interface Note {
+  /** MIDI note number (A4 = 69). */
+  midi: number;
+  /** Chromatic name, e.g. 'A'. */
+  name: NoteName;
+  /** Scientific-pitch octave (A4 lives in octave 4). */
+  octave: number;
+  /** The reference frequency of the note itself, in Hz. */
+  frequencyHz: number;
+}
+
+/**
+ * A single analysed frame of audio: the detected pitch plus the metadata the
+ * app surfaces (clarity/accuracy). `frequencyHz` is null when no pitch was
+ * confidently detected (e.g. silence or unvoiced sound).
+ */
+export interface PitchSample {
+  /** Milliseconds from the start of the recording. */
+  timestampMs: number;
+  /** Detected fundamental frequency in Hz, or null if none. */
+  frequencyHz: number | null;
+  /** MPM clarity for the frame, in [0, 1]. */
+  clarity: number;
+  /** Nearest MIDI note number, or null when no pitch was detected. */
+  midi: number | null;
+  /** Cents away from the nearest note (−50..+50), or null. */
+  cents: number | null;
+}

--- a/packages/models/src/recording.ts
+++ b/packages/models/src/recording.ts
@@ -1,0 +1,17 @@
+import type { PitchSample } from './pitch';
+
+/** Lifecycle of a capture session, mirrored by the client XState machine. */
+export type RecordingStatus = 'idle' | 'recording' | 'analyzing' | 'complete';
+
+/** A captured and analysed take. */
+export interface Recording {
+  id: string;
+  /** Wall-clock creation time, ms since epoch. */
+  createdAtMs: number;
+  /** Capture sample rate in Hz (e.g. 44100). */
+  sampleRateHz: number;
+  /** Total duration in milliseconds. */
+  durationMs: number;
+  /** Per-frame pitch analysis, in capture order. */
+  samples: PitchSample[];
+}


### PR DESCRIPTION
## Summary

First implementation slice of the [audio-engine plan](https://github.com/angusryer/micdrp/blob/main/docs/AUDIO_ENGINE_PLAN.md) — the **pure-TypeScript, framework-agnostic core** that needs no native toolchain and runs identically in Jest, an audio worklet, or (ported) C++. Fills the previously-empty `models` and `logic` stub packages.

### `models`
- `PitchSample`, `Note`, `Recording`, `RecordingStatus`, and `NOTE_NAMES` — the domain types the rest of the pipeline is typed against.

### `logic`
- **`mpm.ts`** — McLeod Pitch Method (NSDF) monophonic pitch detection: `detectPitch(samples, sampleRate, opts) → { frequency, clarity }`, with min/max-frequency bounds. The NSDF clarity doubles as the product's "vocal clarity" metric. Chosen over YIN for singing.
- **`notes.ts`** — `frequencyToMidi` / `midiToFrequency` / `frequencyToNote` (name, octave, cents). ES5-safe math.
- Unit tests: synthetic-sine detection within 1%, silence/bounds handling, and note-conversion cases.

These intentionally **do not cross-import** between packages, so each stays independently typecheck- and test-clean with no workspace-resolution or lockfile changes.

### CI follow-up
- Fixes the client Jest config (`transformIgnorePatterns` now whitelists `react-native-config`) — the one remaining failure when I validated the merged CI pipeline (`lint` ✅, `typecheck` ✅, `test` ❌ on the client suite only). With this, all three jobs should pass.

## Validation
CI auto-runs remain disabled (Actions-minutes conservation, per earlier decision); I validated this branch with a manual `workflow_dispatch` run — see the PR thread for the result.

## Not included (needs a real dev environment)
The RN-upgrade / New-Architecture / native `react-native-audio-api` integration phases require macOS/Android tooling this remote Linux sandbox lacks, so they're intentionally out of this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_