### PR TITLE
feat(logic): note segmentation + MIDI export

### DIFF
--- a/packages/logic/src/__tests__/midi.test.ts
+++ b/packages/logic/src/__tests__/midi.test.ts
@@ -1,0 +1,54 @@
+import { notesToMidi } from '../midi';
+import type { NoteEvent } from '../segmentation';
+
+function note(midi: number, startMs: number, endMs: number): NoteEvent {
+  return {
+    midi,
+    startMs,
+    endMs,
+    durationMs: endMs - startMs,
+    cents: 0,
+    clarity: 0.9
+  };
+}
+
+describe('notesToMidi', () => {
+  it('writes a valid SMF header and track', () => {
+    const smf = notesToMidi([note(69, 0, 500)], {
+      bpm: 120,
+      ticksPerQuarter: 480
+    });
+    const bytes = Array.from(smf);
+
+    // MThd, length 6, format 0, 1 track, division 480 (0x01E0).
+    expect(bytes.slice(0, 4)).toEqual([0x4d, 0x54, 0x68, 0x64]);
+    expect(bytes.slice(4, 8)).toEqual([0, 0, 0, 6]);
+    expect(bytes.slice(8, 10)).toEqual([0, 0]);
+    expect(bytes.slice(10, 12)).toEqual([0, 1]);
+    expect(bytes.slice(12, 14)).toEqual([0x01, 0xe0]);
+    // MTrk chunk follows the 14-byte header.
+    expect(bytes.slice(14, 18)).toEqual([0x4d, 0x54, 0x72, 0x6b]);
+    // Note-on and note-off status bytes are present.
+    expect(bytes).toContain(0x90);
+    expect(bytes).toContain(0x80);
+    // Ends with the end-of-track meta event.
+    expect(bytes.slice(-3)).toEqual([0xff, 0x2f, 0x00]);
+  });
+
+  it('produces a valid (empty) file for no notes', () => {
+    const bytes = Array.from(notesToMidi([]));
+    expect(bytes.slice(0, 4)).toEqual([0x4d, 0x54, 0x68, 0x64]);
+    expect(bytes.slice(-3)).toEqual([0xff, 0x2f, 0x00]);
+    expect(bytes).not.toContain(0x90);
+  });
+
+  it('derives velocity from clarity when not fixed', () => {
+    const bytes = Array.from(notesToMidi([note(60, 0, 250)]));
+    const onIndex = bytes.indexOf(0x90);
+    expect(onIndex).toBeGreaterThan(-1);
+    // velocity byte follows status + note number
+    const velocity = bytes[onIndex + 2];
+    expect(velocity).toBeGreaterThan(0);
+    expect(velocity).toBeLessThanOrEqual(127);
+  });
+});

--- a/packages/logic/src/__tests__/segmentation.test.ts
+++ b/packages/logic/src/__tests__/segmentation.test.ts
@@ -1,0 +1,78 @@
+import { segmentNotes } from '../segmentation';
+import type { PitchFrame } from '../segmentation';
+
+function frame(
+  timestampMs: number,
+  midi: number | null,
+  clarity = 0.95,
+  cents = 0
+): PitchFrame {
+  return { timestampMs, midi, cents, clarity };
+}
+
+describe('segmentNotes', () => {
+  it('splits a stream into distinct notes', () => {
+    const frames: PitchFrame[] = [];
+    for (let t = 0; t <= 90; t += 10) {
+      frames.push(frame(t, 69));
+    }
+    for (let t = 100; t <= 190; t += 10) {
+      frames.push(frame(t, 71));
+    }
+    const notes = segmentNotes(frames, { minDurationMs: 50, maxGapMs: 40 });
+    expect(notes.map((n) => n.midi)).toEqual([69, 71]);
+    expect(notes[0].startMs).toBe(0);
+    expect(notes[0].endMs).toBe(90);
+    expect(notes[0].durationMs).toBe(90);
+    expect(notes[1].startMs).toBe(100);
+  });
+
+  it('drops notes shorter than minDurationMs', () => {
+    const frames = [frame(0, 60), frame(10, 60)];
+    expect(segmentNotes(frames, { minDurationMs: 60 })).toHaveLength(0);
+  });
+
+  it('tolerates short unvoiced gaps within a note', () => {
+    const frames = [
+      frame(0, 69),
+      frame(10, 69),
+      frame(20, 69),
+      frame(30, null),
+      frame(40, 69),
+      frame(50, 69)
+    ];
+    const notes = segmentNotes(frames, { minDurationMs: 30, maxGapMs: 40 });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].midi).toBe(69);
+    expect(notes[0].endMs).toBe(50);
+  });
+
+  it('splits on a long unvoiced gap', () => {
+    const frames = [
+      frame(0, 69),
+      frame(10, 69),
+      frame(20, 69),
+      frame(30, null),
+      frame(40, null),
+      frame(50, null),
+      frame(60, null),
+      frame(70, null),
+      frame(80, 69),
+      frame(90, 69),
+      frame(100, 69)
+    ];
+    const notes = segmentNotes(frames, { minDurationMs: 15, maxGapMs: 40 });
+    expect(notes).toHaveLength(2);
+  });
+
+  it('averages cents and clarity over a note', () => {
+    const frames = [
+      frame(0, 69, 0.8, 10),
+      frame(10, 69, 1.0, 20),
+      frame(20, 69, 0.9, 30)
+    ];
+    const [note] = segmentNotes(frames, { minDurationMs: 10 });
+    expect(note.cents).toBe(20);
+    expect(note.clarity).toBeCloseTo(0.9, 5);
+  });
+});

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -1,2 +1,4 @@
 export * from './mpm';
 export * from './notes';
+export * from './segmentation';
+export * from './midi';

--- a/packages/logic/src/midi.ts
+++ b/packages/logic/src/midi.ts
@@ -1,0 +1,136 @@
+/**
+ * Export detected notes to a Standard MIDI File (format 0).
+ *
+ * Pure byte assembly — no native or filesystem dependencies — so it runs in
+ * Jest and on-device alike. Returns the raw `.mid` bytes.
+ */
+
+import type { NoteEvent } from './segmentation';
+
+export interface MidiOptions {
+  /** Ticks per quarter note (division). Default 480. */
+  ticksPerQuarter?: number;
+  /** Tempo in beats per minute. Default 120. */
+  bpm?: number;
+  /** Fixed note velocity (0..127). When omitted, velocity is derived from clarity. */
+  velocity?: number;
+}
+
+interface MidiEvent {
+  tick: number;
+  /** 1 = note-on, 0 = note-off. */
+  kind: 0 | 1;
+  midi: number;
+  velocity: number;
+}
+
+export function notesToMidi(
+  notes: NoteEvent[],
+  options: MidiOptions = {}
+): Uint8Array {
+  const ticksPerQuarter = options.ticksPerQuarter ?? 480;
+  const bpm = options.bpm ?? 120;
+  const microsPerQuarter = Math.round(60000000 / bpm);
+  const ticksPerMs = ticksPerQuarter / (microsPerQuarter / 1000);
+
+  const events: MidiEvent[] = [];
+  for (let i = 0; i < notes.length; i++) {
+    const note = notes[i];
+    const onTick = Math.max(0, Math.round(note.startMs * ticksPerMs));
+    let offTick = Math.round(note.endMs * ticksPerMs);
+    if (offTick <= onTick) {
+      offTick = onTick + 1;
+    }
+    const velocity =
+      options.velocity != null
+        ? clamp(Math.round(options.velocity), 0, 127)
+        : clamp(Math.round(note.clarity * 127), 1, 127);
+    events.push({ tick: onTick, kind: 1, midi: note.midi, velocity });
+    events.push({ tick: offTick, kind: 0, midi: note.midi, velocity: 0 });
+  }
+
+  // Order by tick; at a tie, emit note-offs before note-ons.
+  events.sort((a, b) => a.tick - b.tick || a.kind - b.kind);
+
+  const track: number[] = [];
+
+  // Tempo meta event at delta 0.
+  pushVarLen(track, 0);
+  track.push(
+    0xff,
+    0x51,
+    0x03,
+    (microsPerQuarter >> 16) & 0xff,
+    (microsPerQuarter >> 8) & 0xff,
+    microsPerQuarter & 0xff
+  );
+
+  let prevTick = 0;
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    pushVarLen(track, ev.tick - prevTick);
+    prevTick = ev.tick;
+    if (ev.kind === 1) {
+      track.push(0x90, ev.midi & 0x7f, ev.velocity & 0x7f);
+    } else {
+      track.push(0x80, ev.midi & 0x7f, 0x40);
+    }
+  }
+
+  // End of track.
+  pushVarLen(track, 0);
+  track.push(0xff, 0x2f, 0x00);
+
+  const out: number[] = [];
+  // Header chunk: MThd, length 6, format 0, 1 track, division.
+  out.push(0x4d, 0x54, 0x68, 0x64);
+  pushUint32(out, 6);
+  pushUint16(out, 0);
+  pushUint16(out, 1);
+  pushUint16(out, ticksPerQuarter);
+  // Track chunk.
+  out.push(0x4d, 0x54, 0x72, 0x6b);
+  pushUint32(out, track.length);
+  for (let i = 0; i < track.length; i++) {
+    out.push(track[i]);
+  }
+
+  return Uint8Array.from(out);
+}
+
+/** Variable-length quantity, big-endian with continuation bits. */
+function pushVarLen(arr: number[], value: number): void {
+  let v = value < 0 ? 0 : Math.floor(value);
+  const groups: number[] = [v & 0x7f];
+  v = Math.floor(v / 128);
+  while (v > 0) {
+    groups.push((v & 0x7f) | 0x80);
+    v = Math.floor(v / 128);
+  }
+  for (let i = groups.length - 1; i >= 0; i--) {
+    arr.push(groups[i]);
+  }
+}
+
+function pushUint32(arr: number[], value: number): void {
+  arr.push(
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff
+  );
+}
+
+function pushUint16(arr: number[], value: number): void {
+  arr.push((value >>> 8) & 0xff, value & 0xff);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}

--- a/packages/logic/src/segmentation.ts
+++ b/packages/logic/src/segmentation.ts
@@ -1,0 +1,99 @@
+/**
+ * Turn a stream of per-frame pitch analyses into discrete sung notes.
+ *
+ * Pure and dependency-free. The input is structurally compatible with
+ * `models.PitchSample` (so a `PitchSample[]` can be passed directly) without
+ * importing across packages.
+ */
+
+export interface PitchFrame {
+  timestampMs: number;
+  midi: number | null;
+  cents: number | null;
+  clarity: number;
+}
+
+export interface NoteEvent {
+  midi: number;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  /** Mean cents deviation across the note. */
+  cents: number;
+  /** Mean clarity across the note, in [0, 1]. */
+  clarity: number;
+}
+
+export interface SegmentOptions {
+  /** Discard notes shorter than this many ms (default 60). */
+  minDurationMs?: number;
+  /** Tolerate unvoiced/changed gaps up to this many ms within a note (default 40). */
+  maxGapMs?: number;
+}
+
+export function segmentNotes(
+  frames: PitchFrame[],
+  options: SegmentOptions = {}
+): NoteEvent[] {
+  const minDuration = options.minDurationMs ?? 60;
+  const maxGap = options.maxGapMs ?? 40;
+
+  const notes: NoteEvent[] = [];
+
+  let curMidi: number | null = null;
+  let startMs = 0;
+  let lastVoicedMs = 0;
+  let centsSum = 0;
+  let claritySum = 0;
+  let count = 0;
+
+  function close(): void {
+    if (curMidi == null) {
+      return;
+    }
+    const durationMs = lastVoicedMs - startMs;
+    if (durationMs >= minDuration && count > 0) {
+      notes.push({
+        midi: curMidi,
+        startMs,
+        endMs: lastVoicedMs,
+        durationMs,
+        cents: Math.round(centsSum / count),
+        clarity: claritySum / count
+      });
+    }
+    curMidi = null;
+    centsSum = 0;
+    claritySum = 0;
+    count = 0;
+  }
+
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+
+    if (f.midi == null) {
+      // Unvoiced frame: end the current note only if the gap is too long.
+      if (curMidi != null && f.timestampMs - lastVoicedMs > maxGap) {
+        close();
+      }
+      continue;
+    }
+
+    if (curMidi == null) {
+      curMidi = f.midi;
+      startMs = f.timestampMs;
+    } else if (f.midi !== curMidi) {
+      close();
+      curMidi = f.midi;
+      startMs = f.timestampMs;
+    }
+
+    lastVoicedMs = f.timestampMs;
+    centsSum += f.cents ?? 0;
+    claritySum += f.clarity;
+    count++;
+  }
+
+  close();
+  return notes;
+}


### PR DESCRIPTION
## Summary

Next slice of the [audio-engine plan](https://github.com/angusryer/micdrp/blob/main/docs/AUDIO_ENGINE_PLAN.md) — pure-TS, still no native toolchain needed.

- **`logic/segmentation.ts`** — `segmentNotes(frames, opts)` turns a stream of per-frame pitch analyses into discrete `NoteEvent`s (start/end/duration + mean cents & clarity), with min-duration filtering and short unvoiced-gap tolerance. Input is structurally compatible with `models.PitchSample`, so a `PitchSample[]` passes directly with **no cross-package import**.
- **`logic/midi.ts`** — `notesToMidi(notes, opts)` assembles a **Standard MIDI File (format 0)** from `NoteEvent`s: VLQ delta-times, tempo meta, note on/off, end-of-track. Returns raw `.mid` bytes; velocity derives from clarity.
- Tests for segmentation (splitting, gap tolerance, min-duration, averaging) and MIDI output (valid header/track bytes, note on/off, end-of-track, velocity bounds).

This completes the offline analysis path: **PCM → `detectPitch` → `PitchSample`s → `segmentNotes` → `notesToMidi`**, all unit-tested.

## Validation
CI auto-runs remain disabled (Actions-minutes conservation); validated via a manual `workflow_dispatch` run — result in the thread.

## Still deferred (needs a real dev environment)
RN upgrade + New Architecture and the native `react-native-audio-api` capture/worklet/Reanimated wiring — they require macOS/Android tooling this sandbox lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_