### PR TITLE
feat(logic): target-pitch scoring

### DIFF
--- a/packages/logic/src/__tests__/scoring.test.ts
+++ b/packages/logic/src/__tests__/scoring.test.ts
@@ -1,0 +1,80 @@
+import { scorePitch } from '../scoring';
+import type { TargetNote } from '../scoring';
+import type { PitchFrame } from '../segmentation';
+
+function frame(
+  timestampMs: number,
+  midi: number | null,
+  cents = 0,
+  clarity = 0.95
+): PitchFrame {
+  return { timestampMs, midi, cents, clarity };
+}
+
+const target = (midi: number, startMs: number, endMs: number): TargetNote => ({
+  midi,
+  startMs,
+  endMs
+});
+
+describe('scorePitch', () => {
+  it('scores a perfect take 100', () => {
+    const frames: PitchFrame[] = [];
+    for (let t = 0; t < 100; t += 10) {
+      frames.push(frame(t, 69, 0));
+    }
+    const result = scorePitch(frames, [target(69, 0, 100)]);
+    expect(result.score).toBe(100);
+    expect(result.inTuneRatio).toBe(1);
+    expect(result.meanCentsError).toBe(0);
+    expect(result.evaluatedFrames).toBe(10);
+  });
+
+  it('treats a consistent 50-cent offset as in-tune at the default tolerance', () => {
+    const frames = [frame(0, 69, 50), frame(10, 69, 50)];
+    const result = scorePitch(frames, [target(69, 0, 100)]);
+    expect(result.inTuneRatio).toBe(1);
+    expect(result.meanCentsError).toBe(50);
+    expect(result.score).toBe(75); // 1 - 50/200 = 0.75
+  });
+
+  it('penalises out-of-tune frames', () => {
+    const frames = [
+      frame(0, 69, 0), // perfect
+      frame(10, 72, 0) // 300 cents sharp
+    ];
+    const result = scorePitch(frames, [target(69, 0, 100)]);
+    expect(result.inTuneRatio).toBe(0.5);
+    expect(result.meanCentsError).toBe(150);
+    expect(result.score).toBe(50); // mean(1, 0) * 100
+  });
+
+  it('ignores octave errors when asked', () => {
+    const frames = [frame(0, 81, 0)]; // an octave above the A4 target
+    expect(scorePitch(frames, [target(69, 0, 100)]).score).toBe(0);
+    expect(
+      scorePitch(frames, [target(69, 0, 100)], { ignoreOctave: true }).score
+    ).toBe(100);
+  });
+
+  it('skips unvoiced frames and frames with no target', () => {
+    const frames = [
+      frame(0, null), // unvoiced
+      frame(10, 69, 0), // on target
+      frame(500, 69, 0) // past the target window
+    ];
+    const result = scorePitch(frames, [target(69, 0, 100)]);
+    expect(result.evaluatedFrames).toBe(1);
+    expect(result.score).toBe(100);
+  });
+
+  it('returns a zero score when nothing is evaluated', () => {
+    const result = scorePitch([frame(0, null)], [target(69, 0, 100)]);
+    expect(result).toEqual({
+      score: 0,
+      inTuneRatio: 0,
+      meanCentsError: 0,
+      evaluatedFrames: 0
+    });
+  });
+});

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -2,3 +2,4 @@ export * from './mpm';
 export * from './notes';
 export * from './segmentation';
 export * from './midi';
+export * from './scoring';

--- a/packages/logic/src/scoring.ts
+++ b/packages/logic/src/scoring.ts
@@ -1,0 +1,108 @@
+/**
+ * Score a sung take against a reference melody.
+ *
+ * Frame-level pitch scoring: for every voiced frame that overlaps a target
+ * note, measure the cents error and aggregate into an in-tune ratio, a mean
+ * cents error, and a smooth 0..100 score. Pure and dependency-free; the input
+ * frame shape is the same `PitchFrame` produced upstream.
+ */
+
+import type { PitchFrame } from './segmentation';
+
+/** A note in the reference melody, with absolute timing. */
+export interface TargetNote {
+  midi: number;
+  startMs: number;
+  endMs: number;
+}
+
+export interface ScoreOptions {
+  /** Cents within which a frame counts as "in tune" (default 50). */
+  toleranceCents?: number;
+  /** Match pitch class only, ignoring octave errors (default false). */
+  ignoreOctave?: boolean;
+}
+
+export interface PitchScore {
+  /** Overall 0..100 score (smoothly degrades with cents error). */
+  score: number;
+  /** Fraction of evaluated frames within tolerance, 0..1. */
+  inTuneRatio: number;
+  /** Mean absolute cents error over evaluated frames. */
+  meanCentsError: number;
+  /** Voiced frames that overlapped a target note and were scored. */
+  evaluatedFrames: number;
+}
+
+/** A frame scores 0 once it is this many cents from the target. */
+const ZERO_SCORE_CENTS = 200;
+
+export function scorePitch(
+  frames: PitchFrame[],
+  targets: TargetNote[],
+  options: ScoreOptions = {}
+): PitchScore {
+  const tolerance = options.toleranceCents ?? 50;
+  const ignoreOctave = options.ignoreOctave ?? false;
+
+  let evaluated = 0;
+  let inTune = 0;
+  let sumAbsError = 0;
+  let sumFrameScore = 0;
+
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+    if (f.midi == null) {
+      continue;
+    }
+    const target = findTarget(targets, f.timestampMs);
+    if (target == null) {
+      continue;
+    }
+
+    let error = (f.midi - target.midi) * 100 + (f.cents ?? 0);
+    if (ignoreOctave) {
+      error = octaveReduce(error);
+    }
+    const absError = Math.abs(error);
+
+    evaluated++;
+    sumAbsError += absError;
+    if (absError <= tolerance) {
+      inTune++;
+    }
+    sumFrameScore += absError >= ZERO_SCORE_CENTS ? 0 : 1 - absError / ZERO_SCORE_CENTS;
+  }
+
+  if (evaluated === 0) {
+    return { score: 0, inTuneRatio: 0, meanCentsError: 0, evaluatedFrames: 0 };
+  }
+
+  return {
+    score: Math.round((sumFrameScore / evaluated) * 100),
+    inTuneRatio: inTune / evaluated,
+    meanCentsError: sumAbsError / evaluated,
+    evaluatedFrames: evaluated
+  };
+}
+
+function findTarget(targets: TargetNote[], timeMs: number): TargetNote | null {
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i];
+    if (timeMs >= t.startMs && timeMs < t.endMs) {
+      return t;
+    }
+  }
+  return null;
+}
+
+/** Fold a cents error into the nearest octave, returning a value in (−600, 600]. */
+function octaveReduce(cents: number): number {
+  let c = cents % 1200;
+  if (c > 600) {
+    c -= 1200;
+  } else if (c <= -600) {
+    c += 1200;
+  }
+  return c;
+}


### PR DESCRIPTION
## Summary

Next core slice — **scoring a sung take against a reference melody** (pure TS, no native deps).

- **`logic/scoring.ts`** — `scorePitch(frames, targets, opts)` evaluates each voiced frame that overlaps a `TargetNote`, measuring cents error, and returns a `PitchScore`:
  - `score` — overall 0..100, degrading smoothly with cents error (0 at ≥200¢ off),
  - `inTuneRatio` — fraction within tolerance (default 50¢),
  - `meanCentsError`,
  - `evaluatedFrames`.
  - Options: `toleranceCents`, `ignoreOctave` (pitch-class matching).
- Tests: perfect take → 100; consistent 50¢ offset → in-tune, score 75; mixed in/out-of-tune; octave-agnostic matching; skipping unvoiced/off-window frames; empty-evaluation case.

Reuses the upstream `PitchFrame` shape, so it chains directly off `detectPitch`/`frequencyToNote` with no cross-package import.

## Validation
Auto-runs stay disabled; validated via manual `workflow_dispatch` — result in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_