### PR TITLE
feat(logic): pitch-stream smoothing

### DIFF
--- a/packages/logic/src/__tests__/smoothing.test.ts
+++ b/packages/logic/src/__tests__/smoothing.test.ts
@@ -1,0 +1,52 @@
+import { smoothPitch } from '../smoothing';
+import type { PitchFrame } from '../segmentation';
+
+function frame(
+  timestampMs: number,
+  midi: number | null,
+  clarity = 0.95,
+  cents = 0
+): PitchFrame {
+  return { timestampMs, midi, cents, clarity };
+}
+
+describe('smoothPitch', () => {
+  it('removes a single-frame outlier via the median', () => {
+    const frames = [
+      frame(0, 69),
+      frame(10, 69),
+      frame(20, 81), // spurious octave jump
+      frame(30, 69),
+      frame(40, 69)
+    ];
+    const out = smoothPitch(frames, { windowSize: 5 });
+    expect(out.map((f) => f.midi)).toEqual([69, 69, 69, 69, 69]);
+  });
+
+  it('gates low-clarity frames to rests (windowSize 1)', () => {
+    const frames = [frame(0, 69, 0.9), frame(10, 70, 0.2), frame(20, 69, 0.9)];
+    const out = smoothPitch(frames, { windowSize: 1, minClarity: 0.5 });
+    expect(out.map((f) => f.midi)).toEqual([69, null, 69]);
+    expect(out[1].cents).toBeNull();
+  });
+
+  it('passes voiced frames through unchanged at windowSize 1', () => {
+    const frames = [frame(0, 69, 0.9, 12), frame(10, 71, 0.9, -8)];
+    const out = smoothPitch(frames, { windowSize: 1 });
+    expect(out.map((f) => f.midi)).toEqual([69, 71]);
+    expect(out.map((f) => f.cents)).toEqual([12, -8]);
+  });
+
+  it('preserves length and timestamps', () => {
+    const frames = [frame(0, 69), frame(10, null), frame(20, 69)];
+    const out = smoothPitch(frames, { windowSize: 3 });
+    expect(out).toHaveLength(3);
+    expect(out.map((f) => f.timestampMs)).toEqual([0, 10, 20]);
+  });
+
+  it('keeps an all-unvoiced stream unvoiced', () => {
+    const frames = [frame(0, null), frame(10, null), frame(20, null)];
+    const out = smoothPitch(frames, { windowSize: 3 });
+    expect(out.every((f) => f.midi === null)).toBe(true);
+  });
+});

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -3,3 +3,4 @@ export * from './notes';
 export * from './segmentation';
 export * from './midi';
 export * from './scoring';
+export * from './smoothing';

--- a/packages/logic/src/smoothing.ts
+++ b/packages/logic/src/smoothing.ts
@@ -1,0 +1,80 @@
+/**
+ * Clean a raw pitch stream before segmentation.
+ *
+ * Raw frame-by-frame detection is jittery: occasional octave jumps, isolated
+ * wrong-note frames, and low-confidence blips. A median filter over the note
+ * (MIDI) values removes single-frame outliers, and a clarity gate turns
+ * low-confidence frames into rests. Pure and dependency-free; operates on the
+ * same `PitchFrame` shape used throughout the pipeline.
+ */
+
+import type { PitchFrame } from './segmentation';
+
+export interface SmoothOptions {
+  /** Median window size in frames; forced odd, min 1. 1 disables the median. Default 5. */
+  windowSize?: number;
+  /** Treat frames below this clarity as unvoiced before filtering. Default 0. */
+  minClarity?: number;
+}
+
+export function smoothPitch(
+  frames: PitchFrame[],
+  options: SmoothOptions = {}
+): PitchFrame[] {
+  const minClarity = options.minClarity ?? 0;
+  let windowSize = options.windowSize ?? 5;
+  if (windowSize < 1) {
+    windowSize = 1;
+  }
+  if (windowSize % 2 === 0) {
+    windowSize += 1;
+  }
+  const half = (windowSize - 1) / 2;
+
+  // Clarity-gate the note values up front.
+  const gated: (number | null)[] = frames.map((f) =>
+    f.midi != null && f.clarity >= minClarity ? f.midi : null
+  );
+
+  const out: PitchFrame[] = [];
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+
+    if (windowSize === 1) {
+      const midi = gated[i];
+      out.push(
+        midi == null
+          ? rest(f)
+          : { timestampMs: f.timestampMs, midi, cents: f.cents, clarity: f.clarity }
+      );
+      continue;
+    }
+
+    const voiced: number[] = [];
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(frames.length - 1, i + half);
+    for (let j = lo; j <= hi; j++) {
+      const m = gated[j];
+      if (m != null) {
+        voiced.push(m);
+      }
+    }
+
+    if (voiced.length === 0) {
+      out.push(rest(f));
+      continue;
+    }
+
+    voiced.sort((a, b) => a - b);
+    const median = voiced[Math.floor((voiced.length - 1) / 2)];
+    // Keep the original cents only when this frame already sat on the median note.
+    const cents = gated[i] === median ? f.cents ?? 0 : 0;
+    out.push({ timestampMs: f.timestampMs, midi: median, cents, clarity: f.clarity });
+  }
+
+  return out;
+}
+
+function rest(f: PitchFrame): PitchFrame {
+  return { timestampMs: f.timestampMs, midi: null, cents: null, clarity: f.clarity };
+}


### PR DESCRIPTION
## Summary

Core slice that makes the pipeline robust on real (jittery) input — pure TS.

- **`logic/smoothing.ts`** — `smoothPitch(frames, opts)` denoises a raw pitch stream **before** segmentation:
  - a **median filter** over MIDI note values removes single-frame outliers (e.g. spurious octave jumps),
  - a **clarity gate** (`minClarity`) turns low-confidence frames into rests.
  - `windowSize` (forced odd, `1` disables the median); same `PitchFrame` in/out so it slots between `detectPitch` and `segmentNotes`.
- Tests: outlier removal, clarity gating, `windowSize=1` passthrough, length/timestamp preservation, all-unvoiced handling.

Recommended pipeline order is now: `detectPitch → smoothPitch → segmentNotes → notesToMidi`, with `scorePitch` for grading.

## Validation
Auto-runs stay disabled; validated via manual `workflow_dispatch` — result in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_