### PR TITLE
feat: practice mode — sing against a target melody

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -27,7 +27,7 @@ merged to `main` unless marked **Phase V** (needs a real dev machine) or
 | **Auth + backend** | Supabase: `src/lib/supabase.ts` + Keychain session adapter (`src/lib/secureSession.ts`); `src/auth/` (AuthContext/useAuth/LoginScreen); `supabase/` (schema, RLS, `takes` storage bucket, `delete_account` RPC). |
 | **Data + sync** | `src/data/recordingsRepo.ts` (cloud CRUD) + `src/data/profilesRepo.ts` (profile + account deletion) + `src/data/currentUser.ts` (shared auth guard) + `src/data/sync.ts` (local-first MMKV cache reconcile); one store. |
 | **Profile** | `src/screens/Profile/` (display-name edit, sign out, delete account) on its own tab; `useProfile` hook. |
-| **Practice (engine)** | `logic/melodies.ts` (target exercise catalogue → `TargetNote[]`) + `audio/referenceTone.ts` (play targets as reference tones). Scoring path (`scorePitch`) already supports external targets. Screen wiring is parked — see `docs/OPEN_QUESTIONS.md`. |
+| **Practice (full)** | Practice tab → pick exercise (`screens/Practice/PracticeScreen`) → `PracticeSession` records against the melody with target+live pitch scrolling in sync (`PracticePitchView`, Skia) and adaptive reference audio (play-along on headphones / count-in otherwise, `usePracticeSession` + `audio/outputRoute`) → Results scores against the chosen melody. Engine: `logic/melodies.ts` + `audio/referenceTone.ts`. Remaining gaps in `docs/OPEN_QUESTIONS.md`. |
 | **On-device feedback** | `src/analysis/feedback.ts` → `FeedbackDto` from `logic`, surfaced in Results. |
 | **i18n** | `src/i18n/` (i18next + device locale); Record/Library/Settings keyed. |
 | **CI** | `lint` + `typecheck` + pure-TS `test` all green. Gated to `workflow_dispatch` (manual). |
@@ -117,11 +117,13 @@ Still deferred (small, non-blocking):
 ### Product features
 - **Profile / account management — BUILT** (display-name edit, sign out, delete
   account incl. the `delete_account` RPC). Its own tab.
-- **Practice / target-melody — engine BUILT, UX parked.** `logic/melodies.ts`
-  (catalogue) + `audio/referenceTone.ts` (reference playback) + the existing
-  `scorePitch` target path are done and tested. The screen wiring (how the user
-  picks an exercise, the live target line, reference-playback timing) has genuine
-  UX ambiguity and is documented in `docs/OPEN_QUESTIONS.md`.
+- **Practice / target-melody — BUILT.** Full flow: Practice tab → exercise
+  picker → recorded session with target+live pitch scrolling in sync and adaptive
+  reference audio → Results scored against the chosen melody. Remaining gaps
+  (native headphone-route probe, remote/imported catalogue, rubato scoring) are in
+  `docs/OPEN_QUESTIONS.md`.
+- **Results "tap a note to hear it"** and **password reset** (Login "Forgot
+  password?") also shipped.
 - **Sharing/social** — still future scope (see `docs/OPEN_QUESTIONS.md`).
 
 ---

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,67 +1,54 @@
 # micdrp — Open product questions
 
-Things that are **logically buildable but where the product intent is not yet
-clear**. Per the working agreement, the unambiguous engine/data layers are built
-and tested; the decisions below are parked here so the UX can be settled before
-wiring them into the screens. Nothing here blocks the merged work.
+Decisions that have been settled are recorded here with what shipped; what
+remains genuinely open is called out at the end. Nothing here blocks merged work.
 
 ---
 
-## 1. Practice / target-melody mode (sing *against* a target)
+## 1. Practice / target-melody mode — BUILT
 
-**Built and tested (clear intent):**
-- `logic/melodies.ts` — a deterministic catalogue of practice exercises
-  (`PRACTICE_MELODIES`: major/minor scales, arpeggio, fifths, octave leaps, a
-  nursery tune) that build absolute-timed `TargetNote[]`, transposable by root
-  and pace. Pure music theory, fully unit-tested.
-- `audio/referenceTone.ts` — `createReferenceTonePlayer()` plays any
-  `TargetNote[]` as reference tones (one enveloped sine per note, pitched via the
-  shared `midiToFrequency`), so what the singer hears is exactly what the scorer
-  grades. Inert no-op when the audio package is absent; unit-tested via an
-  injected context.
-- Scoring already supports an external target: `scorePitch(frames, targets)`.
+Decisions (from the product Q&A) and how they shipped:
 
-**Open questions before wiring it into the Record/Results screens:**
-1. **Selection UX.** Where does the user pick an exercise — a new "Practice" tab,
-   a mode toggle on the Record screen, or a pre-roll sheet? Does the choice
-   persist as a default?
-2. **Live target display.** During a take, should the Record screen draw the
-   target line/notes alongside the live pitch line (Skia), and should it scroll
-   in sync with a transport clock? This touches the real-time render path, so the
-   interaction model (countdown, looping, tempo control) needs to be pinned down
-   first.
-3. **Reference playback timing.** Play the reference once before recording, or
-   simultaneously (singer follows along)? Simultaneous playback risks the mic
-   capturing the reference tone — do we need it muted-through-headphones-only, or
-   a short count-in then silence?
-4. **Scoring window.** Use the melody's own timeline as-is, or time-align the
-   sung take to the target (allow the singer to start late / rubato) before
-   scoring? Today `scorePitch` matches by absolute timestamp.
-5. **Catalogue source.** Is the built-in exercise set enough for v1, or do we
-   want user-imported songs / a remote song library? (If remote, it's a new
-   Supabase table + storage, mirroring `recordings`.)
+| Decision | Choice | Where |
+|---|---|---|
+| Entry point | Dedicated **Practice tab** | `screens/Practice/PracticeScreen` + a 5th tab |
+| Reference audio | **Adaptive**: play-along on headphones, else count-in | `usePracticeSession` + `audio/outputRoute` |
+| Live visuals | **Target + live line scrolling in sync** | `screens/Practice/PracticePitchView` (Skia) |
+| Scoring | **Fixed timeline** (absolute time) | `logic.scorePitch` + `analysis/feedback` |
+| Catalogue | **Built-in exercises only** for v1 | `logic/melodies.ts` |
 
-## 2. Reference-tone affordances outside practice mode
+Flow: pick an exercise (+ key/pace) → `PracticeSession` runs the count-in or
+play-along, records for the melody's length while the target + live pitch scroll
+together → `Results` scores the take against that melody (per-target feedback).
 
-Should the Results screen let the user tap a detected note to hear its reference
-pitch (using the same `referenceTone` player)? Cheap to add, but it's unclear if
-that's desired or clutter.
+**Still open / deferred here:**
+1. **Headphone-route detection is pluggable but not yet wired to a native
+   module.** `audio/outputRoute.detectHeadphonesConnected()` returns `false`
+   (→ count-in) until a probe is registered via `setHeadphoneProbe`. Wire a small
+   native route check (iOS `AVAudioSession.currentRoute`, Android
+   `AudioManager`/`AudioDeviceInfo`) in Phase V so play-along actually engages on
+   headphones.
+2. **Catalogue growth** — remote song library (a Supabase `melodies` table) or
+   user MIDI import were deferred; built-in set ships first.
+3. **Timing tolerance** — fixed-timeline scoring ships; rubato/time-aligned
+   ("warp the take to the target") scoring was deferred as a later enhancement.
+4. **Transport polish** — no on-screen countdown digits or progress bar yet
+   (the status text + scrolling target convey position); add if it tests poorly.
 
-## 3. Social / sharing
+## 2. Results: tap a note to hear its pitch — BUILT
 
-The handoff lists "sharing/social" as future scope. MIDI export + share already
-exists. Open: do we want shareable links to a take (public read via a signed/long
-URL or a public bucket path), a feed, or follower mechanics? Each is a different
-data-model and privacy decision — not started, deliberately.
+`Results` → `NoteList` rows are tappable and play the note's reference pitch via
+the shared `referenceTone` player.
 
-## 4. Account specifics (Profile shipped; edges to confirm)
+## 3. Sharing / social — DEFERRED
 
-The Profile screen ships with display-name editing, sign-out, and
-delete-account. Two things to confirm against the real backend:
-- **`delete_account` RPC privileges.** It is `security definer` and deletes the
-  caller's `auth.users` row (cascading profiles + recordings). On some Supabase
-  projects the function owner may lack delete rights on `auth.users`; if so, move
-  account deletion to an Edge Function using the service-role key. Verify on a
-  real project (Phase V).
-- **Email change / password reset.** Not built. Supabase supports both
-  (`updateUser`, `resetPasswordForEmail`); add to Profile if wanted.
+Unchanged: MIDI export/share only. Shareable take links / feed / follows remain
+future scope (each is a separate data-model + privacy decision).
+
+## 4. Account features
+
+- **Password reset — BUILT.** `useAuth().resetPassword` + a "Forgot password?"
+  affordance on the Login screen (Supabase `resetPasswordForEmail`).
+- **Email change** — not built (deferred); Supabase `updateUser` supports it.
+- **`delete_account` RPC privileges** — still to verify on a real Supabase
+  project (fallback: an Edge Function with the service role). Phase V check.

--- a/packages/client/src/analysis/__tests__/feedback.test.ts
+++ b/packages/client/src/analysis/__tests__/feedback.test.ts
@@ -112,3 +112,38 @@ describe('computeFeedback', () => {
     expect(fb.suggestions.length).toBeGreaterThan(0);
   });
 });
+
+describe('computeFeedback against an external practice melody', () => {
+  // The fixture sings A3, C4, E4, A4, each held for 500ms.
+  const matchingTargets = [
+    { midi: 57, startMs: 0, endMs: 500 },
+    { midi: 60, startMs: 500, endMs: 1000 },
+    { midi: 64, startMs: 1000, endMs: 1500 },
+    { midi: 69, startMs: 1500, endMs: 2000 }
+  ];
+
+  it('scores a take that matches the target melody highly, one perNote per target', () => {
+    const fb = computeFeedback(makeHandle(melodyFixture([0, 0, 0, 0])), matchingTargets);
+
+    expect(fb.overallScore).toBeGreaterThan(90);
+    expect(fb.perNote).toHaveLength(matchingTargets.length);
+    expect(fb.perNote.map((n) => n.midi)).toEqual([57, 60, 64, 69]);
+    expect(fb.perNote.every((n) => n.inTune)).toBe(true);
+  });
+
+  it('punishes a take sung a tone away from the target', () => {
+    // Target a whole tone above what was actually sung → every note is ~200 cents off.
+    const shifted = matchingTargets.map((t) => ({ ...t, midi: t.midi + 2 }));
+    const fb = computeFeedback(makeHandle(melodyFixture([0, 0, 0, 0])), shifted);
+
+    expect(fb.overallScore).toBeLessThan(50);
+    expect(fb.perNote.every((n) => !n.inTune)).toBe(true);
+  });
+
+  it('falls back to self-scoring when given an empty target list', () => {
+    const fb = computeFeedback(makeHandle(melodyFixture([0, 0, 0, 0])), []);
+    // Same as the no-argument self-referential behaviour.
+    expect(fb.perNote.map((n) => n.midi)).toEqual([57, 60, 64, 69]);
+    expect(fb.overallScore).toBeGreaterThan(90);
+  });
+});

--- a/packages/client/src/analysis/feedback.ts
+++ b/packages/client/src/analysis/feedback.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_TOLERANCE_CENTS,
   type KeyEstimate,
   type NoteEvent,
+  type PitchFrame,
   type PitchScore,
   type TargetNote
 } from 'logic';
@@ -58,6 +59,38 @@ function selfTargets(notes: readonly NoteEvent[]): TargetNote[] {
     targets.push({ midi: n.midi, startMs: n.startMs, endMs: n.endMs });
   }
   return targets;
+}
+
+/**
+ * Per-target feedback for a practice take: for each note of the reference
+ * melody, average the signed cents error of the voiced frames that fell in its
+ * time window. A target with no voiced frames is reported as not-in-tune (the
+ * singer missed/skipped it). Used only when scoring against an external melody.
+ */
+function perTargetFeedback(
+  frames: readonly PitchFrame[],
+  targets: readonly TargetNote[]
+): NoteFeedback[] {
+  return targets.map((target, index) => {
+    let sum = 0;
+    let count = 0;
+    for (const f of frames) {
+      if (f.midi == null) {
+        continue;
+      }
+      if (f.timestampMs >= target.startMs && f.timestampMs < target.endMs) {
+        sum += (f.midi - target.midi) * 100 + (f.cents ?? 0);
+        count++;
+      }
+    }
+    const centsError = count > 0 ? sum / count : 0;
+    return {
+      index,
+      midi: target.midi,
+      centsError,
+      inTune: count > 0 && Math.abs(centsError) <= DEFAULT_TOLERANCE_CENTS
+    };
+  });
 }
 
 /** Per-note feedback from the segmentation (mean cents deviation per note). */
@@ -155,12 +188,22 @@ function narrate(
 
 /**
  * Run the full offline feedback pipeline over a finished capture and synthesize
- * a {@link FeedbackDto}. Pure: depends only on `handle.samples`.
+ * a {@link FeedbackDto}. Pure: depends only on `handle.samples` (+ the optional
+ * reference melody).
+ *
+ * When `externalTargets` is supplied (a practice take sung against a chosen
+ * melody) the take is scored against THAT melody and `perNote` reports one entry
+ * per target note. With no targets it falls back to the self-referential grid
+ * (how steadily each sung note was held), the unaccompanied-take behaviour.
  */
-export function computeFeedback(handle: RecordingHandle): FeedbackDto {
+export function computeFeedback(
+  handle: RecordingHandle,
+  externalTargets?: readonly TargetNote[]
+): FeedbackDto {
   const smoothed = smoothPitch(handle.samples);
   const notes = segmentNotes(smoothed);
-  const targets = selfTargets(notes);
+  const usingTargets = externalTargets != null && externalTargets.length > 0;
+  const targets = usingTargets ? [...externalTargets] : selfTargets(notes);
   const score = scorePitch(smoothed, targets);
   const key = detectKey(notes);
   const tempo = estimateTempo(notes);
@@ -179,7 +222,9 @@ export function computeFeedback(handle: RecordingHandle): FeedbackDto {
     meanCentsError: score.meanCentsError,
     key: keyLabel,
     tempoBpm,
-    perNote: perNoteFeedback(notes),
+    perNote: usingTargets
+      ? perTargetFeedback(smoothed, targets)
+      : perNoteFeedback(notes),
     ...narrative
   };
 }

--- a/packages/client/src/audio/__tests__/outputRoute.test.ts
+++ b/packages/client/src/audio/__tests__/outputRoute.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for output-route (headphone) detection. The probe is pluggable, so
+ * we drive both routes and the safe-default/error paths directly.
+ */
+import {
+  detectHeadphonesConnected,
+  setHeadphoneProbe
+} from '../outputRoute';
+
+afterEach(() => {
+  setHeadphoneProbe(null);
+});
+
+describe('detectHeadphonesConnected', () => {
+  it('defaults to false (speaker) when no probe is registered', async () => {
+    await expect(detectHeadphonesConnected()).resolves.toBe(false);
+  });
+
+  it('returns true when the probe reports headphones', async () => {
+    setHeadphoneProbe(() => true);
+    await expect(detectHeadphonesConnected()).resolves.toBe(true);
+  });
+
+  it('awaits an async probe', async () => {
+    setHeadphoneProbe(() => Promise.resolve(true));
+    await expect(detectHeadphonesConnected()).resolves.toBe(true);
+  });
+
+  it('falls back to false when the probe throws', async () => {
+    setHeadphoneProbe(() => {
+      throw new Error('route unavailable');
+    });
+    await expect(detectHeadphonesConnected()).resolves.toBe(false);
+  });
+
+  it('falls back to false when the probe rejects', async () => {
+    setHeadphoneProbe(() => Promise.reject(new Error('nope')));
+    await expect(detectHeadphonesConnected()).resolves.toBe(false);
+  });
+});

--- a/packages/client/src/audio/outputRoute.ts
+++ b/packages/client/src/audio/outputRoute.ts
@@ -1,0 +1,46 @@
+/**
+ * outputRoute — best-effort detection of whether headphones (wired or Bluetooth)
+ * are the current audio output.
+ *
+ * Practice uses this to decide how the reference melody is presented:
+ *   - headphones connected → play the reference WHILE recording (play-along),
+ *     since the mic won't capture tones that go to the singer's ears;
+ *   - otherwise → play a count-in preview, then record in silence so the speaker
+ *     output never bleeds into the take.
+ *
+ * React Native has no first-class audio-route API, so detection is pluggable: a
+ * native module (or a future `react-native-audio-api` capability) can register a
+ * probe via {@link setHeadphoneProbe}. With nothing registered we return `false`
+ * (speaker → count-in) — the safe default that never feeds the reference into
+ * the mic.
+ */
+
+/** A probe returns true when headphones are the active output. */
+export type HeadphoneProbe = () => Promise<boolean> | boolean;
+
+let injectedProbe: HeadphoneProbe | null = null;
+
+/**
+ * Register (or clear, with `null`) the headphone-route probe. Wire a native
+ * module here once available; tests use it to simulate either route.
+ */
+export function setHeadphoneProbe(probe: HeadphoneProbe | null): void {
+  injectedProbe = probe;
+}
+
+/**
+ * Resolve whether headphones are currently the audio output. Never rejects —
+ * any probe error resolves to `false` (assume speaker), so callers can choose a
+ * presentation mode without guarding.
+ */
+export async function detectHeadphonesConnected(): Promise<boolean> {
+  if (!injectedProbe) {
+    // No route probe registered (no native capability yet) → assume speaker.
+    return false;
+  }
+  try {
+    return Boolean(await injectedProbe());
+  } catch {
+    return false;
+  }
+}

--- a/packages/client/src/auth/AuthContext.tsx
+++ b/packages/client/src/auth/AuthContext.tsx
@@ -36,6 +36,8 @@ export interface AuthContextValue {
   signIn(email: string, password: string): Promise<void>;
   signUp(email: string, password: string): Promise<void>;
   signOut(): Promise<void>;
+  /** Email the user a password-reset link. */
+  resetPassword(email: string): Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -106,6 +108,13 @@ export function AuthProvider({
     }
   }, []);
 
+  const resetPassword = useCallback(async (email: string): Promise<void> => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    if (error) {
+      throw toAppError(error, 'Could not send a reset email.');
+    }
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       session,
@@ -113,9 +122,10 @@ export function AuthProvider({
       loading,
       signIn,
       signUp,
-      signOut
+      signOut,
+      resetPassword
     }),
-    [session, loading, signIn, signUp, signOut]
+    [session, loading, signIn, signUp, signOut, resetPassword]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/client/src/auth/__tests__/AuthContext.test.tsx
+++ b/packages/client/src/auth/__tests__/AuthContext.test.tsx
@@ -16,6 +16,7 @@ const onAuthStateChange = jest.fn();
 const signInWithPassword = jest.fn();
 const signUp = jest.fn();
 const signOut = jest.fn();
+const resetPasswordForEmail = jest.fn();
 const unsubscribe = jest.fn();
 
 jest.mock('../../lib/supabase', () => ({
@@ -24,7 +25,8 @@ jest.mock('../../lib/supabase', () => ({
       onAuthStateChange: (...args: unknown[]) => onAuthStateChange(...args),
       signInWithPassword: (...args: unknown[]) => signInWithPassword(...args),
       signUp: (...args: unknown[]) => signUp(...args),
-      signOut: (...args: unknown[]) => signOut(...args)
+      signOut: (...args: unknown[]) => signOut(...args),
+      resetPasswordForEmail: (...args: unknown[]) => resetPasswordForEmail(...args)
     }
   }
 }));
@@ -116,6 +118,18 @@ describe('AuthProvider / useAuth', () => {
     });
 
     expect(signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetPassword delegates to supabase.auth.resetPasswordForEmail', async () => {
+    wireListener();
+    resetPasswordForEmail.mockResolvedValue({ error: null });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.resetPassword('a@b.c');
+    });
+
+    expect(resetPasswordForEmail).toHaveBeenCalledWith('a@b.c');
   });
 
   it('maps a Supabase auth error onto the shared AppError shape', async () => {

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -70,6 +70,32 @@
     "note_other": "{{count}} notes",
     "refreshing": "Refreshing…"
   },
+  "practice": {
+    "title": "Practice",
+    "subtitle": "Sing against a target melody.",
+    "key": "Key",
+    "keyUp": "Raise key",
+    "keyDown": "Lower key",
+    "pace": "Pace",
+    "paces": {
+      "slow": "Slow",
+      "medium": "Medium",
+      "fast": "Fast"
+    },
+    "start": "Start",
+    "startLabel": "Practise {{name}}",
+    "session": {
+      "getReady": "Get ready",
+      "listen": "Listen…",
+      "sing": "Sing!",
+      "analyzing": "Analyzing…",
+      "start": "Start",
+      "stop": "Stop",
+      "back": "Back",
+      "micDenied": "Microphone permission is needed to practise.",
+      "failed": "Something went wrong with this take."
+    }
+  },
   "profile": {
     "title": "Profile",
     "sections": {

--- a/packages/client/src/navigation/RootNavigator.tsx
+++ b/packages/client/src/navigation/RootNavigator.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { useAuth } from '../auth';
 import LibraryScreen from '../screens/Library/LibraryScreen';
 import LoginScreen from '../screens/Login/LoginScreen';
+import PracticeScreen from '../screens/Practice/PracticeScreen';
+import PracticeSessionScreen from '../screens/Practice/PracticeSessionScreen';
 import ProfileScreen from '../screens/Profile/ProfileScreen';
 import RecordScreen from '../screens/Record/RecordScreen';
 import ResultsScreen from '../screens/Results/ResultsScreen';
@@ -23,6 +25,7 @@ function MainTabs() {
   return (
     <Tab.Navigator screenOptions={{ headerShown: false }}>
       <Tab.Screen name='Record' component={RecordScreen} />
+      <Tab.Screen name='Practice' component={PracticeScreen} />
       <Tab.Screen name='Library' component={LibraryScreen} />
       <Tab.Screen name='Profile' component={ProfileScreen} />
       <Tab.Screen name='Settings' component={SettingsScreen} />
@@ -42,6 +45,10 @@ export default function RootNavigator() {
       {session ? (
         <Stack.Navigator screenOptions={{ headerShown: false }}>
           <Stack.Screen name='Main' component={MainTabs} />
+          <Stack.Screen
+            name='PracticeSession'
+            component={PracticeSessionScreen}
+          />
           <Stack.Screen
             name='Results'
             component={ResultsScreen}

--- a/packages/client/src/navigation/types.ts
+++ b/packages/client/src/navigation/types.ts
@@ -1,12 +1,29 @@
 import type { RecordingHandle } from '../audio/contract';
 
 /**
+ * Parameters that identify a practice exercise — passed (serialisably) through
+ * navigation so the session and Results can rebuild the same `TargetNote[]` from
+ * the `logic` catalogue. Kept as id + transposition rather than the note array
+ * so route params stay small and JSON-safe.
+ */
+export interface PracticeParams {
+  /** Catalogue id (see `logic` PRACTICE_MELODIES). */
+  melodyId: string;
+  /** Tonic MIDI the exercise is built from. */
+  rootMidi: number;
+  /** Duration of each note in ms. */
+  noteDurationMs: number;
+}
+
+/**
  * Route maps for the app. Screens are typed against these via
  * `NativeStackScreenProps`/`BottomTabScreenProps`.
  */
 export type RootStackParamList = {
   Main: undefined;
-  Results: { handle: RecordingHandle };
+  PracticeSession: PracticeParams;
+  /** `practice` is set when the take was sung against a target melody. */
+  Results: { handle: RecordingHandle; practice?: PracticeParams };
 };
 
 /** Unauthenticated stack, shown when there is no Supabase session. */
@@ -16,6 +33,7 @@ export type AuthStackParamList = {
 
 export type MainTabParamList = {
   Record: undefined;
+  Practice: undefined;
   Library: undefined;
   Profile: undefined;
   Settings: undefined;

--- a/packages/client/src/screens/Login/LoginScreen.tsx
+++ b/packages/client/src/screens/Login/LoginScreen.tsx
@@ -28,13 +28,14 @@ type Mode = 'signIn' | 'signUp';
 
 export default function LoginScreen(): React.JSX.Element {
   const { colors } = useTheme();
-  const { signIn, signUp } = useAuth();
+  const { signIn, signUp, resetPassword } = useAuth();
 
   const [mode, setMode] = useState<Mode>('signIn');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   const isSignUp = mode === 'signUp';
   const canSubmit =
@@ -65,7 +66,28 @@ export default function LoginScreen(): React.JSX.Element {
   const toggleMode = useCallback(() => {
     setMode((m) => (m === 'signIn' ? 'signUp' : 'signIn'));
     setError(null);
+    setNotice(null);
   }, []);
+
+  const onForgotPassword = useCallback(async () => {
+    const trimmedEmail = email.trim();
+    if (trimmedEmail.length === 0) {
+      setNotice(null);
+      setError('Enter your email to reset your password.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await resetPassword(trimmedEmail);
+      setNotice('Check your email for a reset link.');
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [email, resetPassword]);
 
   const inputStyle = useMemo(
     () => [
@@ -130,6 +152,15 @@ export default function LoginScreen(): React.JSX.Element {
             </Text>
           ) : null}
 
+          {notice ? (
+            <Text
+              style={[styles.notice, { color: colors.primary500 }]}
+              accessibilityLiveRegion="polite"
+            >
+              {notice}
+            </Text>
+          ) : null}
+
           <TouchableOpacity
             style={[
               styles.button,
@@ -170,6 +201,20 @@ export default function LoginScreen(): React.JSX.Element {
                 : "Don't have an account? Sign up"}
             </Text>
           </TouchableOpacity>
+
+          {!isSignUp ? (
+            <TouchableOpacity
+              style={styles.forgot}
+              onPress={() => void onForgotPassword()}
+              disabled={submitting}
+              accessibilityRole="button"
+              accessibilityLabel="Reset your password"
+            >
+              <Text style={[styles.forgotText, { color: colors.gray300 }]}>
+                Forgot password?
+              </Text>
+            </TouchableOpacity>
+          ) : null}
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -212,6 +257,12 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     textAlign: 'center'
   },
+  notice: {
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: 'center',
+    fontWeight: '600'
+  },
   button: {
     height: 52,
     borderRadius: 12,
@@ -230,5 +281,13 @@ const styles = StyleSheet.create({
   toggleText: {
     fontSize: 14,
     fontWeight: '600'
+  },
+  forgot: {
+    marginTop: 12,
+    alignItems: 'center'
+  },
+  forgotText: {
+    fontSize: 13,
+    fontWeight: '500'
   }
 });

--- a/packages/client/src/screens/Practice/PracticePitchView.tsx
+++ b/packages/client/src/screens/Practice/PracticePitchView.tsx
@@ -1,0 +1,192 @@
+/**
+ * PracticePitchView — the practice canvas: the target melody + the live sung
+ * pitch, sharing one scrolling time axis, drawn entirely on the UI thread.
+ *
+ * The `sharedFrame` counter (bumped once per emitted audio frame by
+ * useRecordController) is the transport clock: `currentMs = frame / fps * 1000`.
+ * A "now" marker sits at `nowFraction` of the width; target notes to its right
+ * are upcoming, to its left already sung. The live trace is a ring buffer whose
+ * newest sample sits exactly at "now", so the two layers line up in time.
+ *
+ * The worklets inline the formulas from `practiceLayout.ts` (Reanimated worklets
+ * can't call across modules); that module unit-tests the identical math.
+ */
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Canvas, Path, Skia } from '@shopify/react-native-skia';
+import {
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue
+} from 'react-native-reanimated';
+import type { TargetNote } from 'logic';
+
+import { useTheme } from '../../theme';
+import { UNVOICED_MIDI } from '../Record/useRecordController';
+
+export interface PracticePitchViewProps {
+  sharedMidi: SharedValue<number>;
+  sharedFrame: SharedValue<number>;
+  /** The reference melody to draw (absolute-timed). */
+  targets: readonly TargetNote[];
+  width: number;
+  height: number;
+  /** Emit rate (frames/sec) — the transport clock's tick rate. Default 60. */
+  fps?: number;
+  /** Total visible time span in ms. Default 4000. */
+  windowMs?: number;
+  /** Horizontal position of "now", 0..1. Default 0.6. */
+  nowFraction?: number;
+  minMidi?: number;
+  maxMidi?: number;
+}
+
+const DEFAULT_FPS = 60;
+const DEFAULT_WINDOW_MS = 4000;
+const DEFAULT_NOW_FRACTION = 0.6;
+const DEFAULT_MIN_MIDI = 45;
+const DEFAULT_MAX_MIDI = 84;
+
+export function PracticePitchView({
+  sharedMidi,
+  sharedFrame,
+  targets,
+  width,
+  height,
+  fps = DEFAULT_FPS,
+  windowMs = DEFAULT_WINDOW_MS,
+  nowFraction = DEFAULT_NOW_FRACTION,
+  minMidi = DEFAULT_MIN_MIDI,
+  maxMidi = DEFAULT_MAX_MIDI
+}: PracticePitchViewProps): React.JSX.Element {
+  const { colors } = useTheme();
+
+  const frameMs = 1000 / fps;
+  const pxPerMs = width / windowMs;
+  const nowXv = width * nowFraction;
+  const span = Math.max(1, maxMidi - minMidi);
+
+  // Enough history to fill the "past" portion (left of now) plus a margin.
+  const historyLength = Math.ceil((nowFraction * windowMs) / frameMs) + 8;
+
+  const history = useSharedValue<number[]>(
+    new Array<number>(historyLength).fill(UNVOICED_MIDI)
+  );
+  const lastFrame = useSharedValue(-1);
+
+  // ---- Target melody layer (horizontal segments, scrolling) ----
+  const targetPath = useDerivedValue(() => {
+    'worklet';
+    const currentMs = sharedFrame.value * frameMs;
+    const p = Skia.Path.Make();
+    for (let i = 0; i < targets.length; i++) {
+      const t = targets[i];
+      const x1 = nowXv + (t.startMs - currentMs) * pxPerMs;
+      const x2 = nowXv + (t.endMs - currentMs) * pxPerMs;
+      if (x2 < 0 || x1 > width) {
+        continue;
+      }
+      const norm = (t.midi - minMidi) / span;
+      const clamped = norm < 0 ? 0 : norm > 1 ? 1 : norm;
+      const y = height - clamped * height;
+      const a = x1 < 0 ? 0 : x1;
+      const b = x2 > width ? width : x2;
+      p.moveTo(a, y);
+      p.lineTo(b, y);
+    }
+    return p;
+  }, [targets, width, height, frameMs, pxPerMs, nowXv, span, minMidi, maxMidi]);
+
+  // ---- Live sung-pitch layer (ring buffer, newest at "now") ----
+  const livePath = useDerivedValue(() => {
+    'worklet';
+    const frame = sharedFrame.value;
+    if (frame !== lastFrame.value) {
+      lastFrame.value = frame;
+      const next = history.value;
+      next.push(sharedMidi.value);
+      if (next.length > historyLength) {
+        next.shift();
+      }
+      history.value = next;
+    }
+
+    const p = Skia.Path.Make();
+    const buf = history.value;
+    const n = buf.length;
+    let penDown = false;
+    for (let i = 0; i < n; i++) {
+      const midi = buf[i];
+      if (midi === UNVOICED_MIDI) {
+        penDown = false;
+        continue;
+      }
+      // Newest sample (i = n-1) sits at "now"; older samples scroll left.
+      const offsetFrames = n - 1 - i;
+      const x = nowXv - offsetFrames * frameMs * pxPerMs;
+      if (x < 0) {
+        penDown = false;
+        continue;
+      }
+      const norm = (midi - minMidi) / span;
+      const clamped = norm < 0 ? 0 : norm > 1 ? 1 : norm;
+      const y = height - clamped * height;
+      if (penDown) {
+        p.lineTo(x, y);
+      } else {
+        p.moveTo(x, y);
+        penDown = true;
+      }
+    }
+    return p;
+  }, [width, height, frameMs, pxPerMs, nowXv, span, historyLength, minMidi, maxMidi]);
+
+  // ---- Static "now" marker (vertical line) ----
+  const nowLine = useMemo(() => {
+    const p = Skia.Path.Make();
+    p.moveTo(nowXv, 0);
+    p.lineTo(nowXv, height);
+    return p;
+  }, [nowXv, height]);
+
+  const containerStyle = useMemo(
+    () => [styles.container, { width, height }],
+    [width, height]
+  );
+
+  return (
+    <View style={containerStyle}>
+      <Canvas style={styles.canvas}>
+        <Path
+          path={targetPath}
+          color={colors.gray300}
+          style="stroke"
+          strokeWidth={8}
+          strokeCap="round"
+          opacity={0.6}
+        />
+        <Path
+          path={nowLine}
+          color={colors.gray500}
+          style="stroke"
+          strokeWidth={StyleSheet.hairlineWidth}
+        />
+        <Path
+          path={livePath}
+          color={colors.primary500}
+          style="stroke"
+          strokeWidth={3}
+          strokeJoin="round"
+          strokeCap="round"
+        />
+      </Canvas>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { overflow: 'hidden' },
+  canvas: { flex: 1 }
+});
+
+export default PracticePitchView;

--- a/packages/client/src/screens/Practice/PracticeScreen.tsx
+++ b/packages/client/src/screens/Practice/PracticeScreen.tsx
@@ -1,0 +1,237 @@
+/**
+ * PracticeScreen — pick a target exercise to sing against (the Practice tab).
+ *
+ * Lists the built-in `logic` melody catalogue plus two global controls (key /
+ * pace). Selecting a melody navigates to the PracticeSession route with the
+ * chosen melody id + transposition, where the take is recorded against it.
+ *
+ * Presentational + light state only; the exercise data and timing live in
+ * `logic`, the session orchestration in `usePracticeSession`.
+ */
+import React, { useCallback, useState } from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { CompositeScreenProps } from '@react-navigation/native';
+import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { PRACTICE_MELODIES } from 'logic';
+
+import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
+import type {
+  MainTabParamList,
+  RootStackParamList
+} from '../../navigation/types';
+import { midiToLabel } from '../Results/NoteList';
+
+export type PracticeScreenProps = CompositeScreenProps<
+  BottomTabScreenProps<MainTabParamList, 'Practice'>,
+  NativeStackScreenProps<RootStackParamList>
+>;
+
+type PracticeNavigation = PracticeScreenProps['navigation'];
+
+/** Pace presets → ms per note. */
+const PACES = [
+  { key: 'slow', noteDurationMs: 700 },
+  { key: 'medium', noteDurationMs: 500 },
+  { key: 'fast', noteDurationMs: 350 }
+] as const;
+
+const MIN_ROOT_MIDI = 48; // C3
+const MAX_ROOT_MIDI = 72; // C5
+const DEFAULT_ROOT_MIDI = 60; // C4
+
+export function PracticeScreen(): React.JSX.Element {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const navigation = useNavigation<PracticeNavigation>();
+
+  const [rootMidi, setRootMidi] = useState(DEFAULT_ROOT_MIDI);
+  const [paceIndex, setPaceIndex] = useState(1); // medium
+
+  const noteDurationMs = PACES[paceIndex].noteDurationMs;
+
+  const stepRoot = useCallback((delta: number) => {
+    setRootMidi((m) => Math.min(MAX_ROOT_MIDI, Math.max(MIN_ROOT_MIDI, m + delta)));
+  }, []);
+
+  const start = useCallback(
+    (melodyId: string) => {
+      navigation.navigate('PracticeSession', {
+        melodyId,
+        rootMidi,
+        noteDurationMs
+      });
+    },
+    [navigation, rootMidi, noteDurationMs]
+  );
+
+  return (
+    <SafeAreaView style={[styles.safe, { backgroundColor: colors.neutral300 }]}>
+      <View style={styles.header}>
+        <Text style={[styles.heading, { color: colors.typography }]}>
+          {t('practice.title')}
+        </Text>
+        <Text style={[styles.subtitle, { color: colors.gray300 }]}>
+          {t('practice.subtitle')}
+        </Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ---- Global controls ---- */}
+        <View
+          style={[
+            styles.controls,
+            { backgroundColor: colors.neutral100, borderColor: colors.neutral500 }
+          ]}
+        >
+          <View style={styles.controlRow}>
+            <Text style={[styles.controlLabel, { color: colors.typography }]}>
+              {t('practice.key')}
+            </Text>
+            <View style={styles.stepper}>
+              <TouchableOpacity
+                onPress={() => stepRoot(-1)}
+                disabled={rootMidi <= MIN_ROOT_MIDI}
+                style={[styles.stepBtn, { backgroundColor: colors.neutral300, opacity: rootMidi <= MIN_ROOT_MIDI ? 0.35 : 1 }]}
+                accessibilityLabel={t('practice.keyDown')}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.primary500 }]}>−</Text>
+              </TouchableOpacity>
+              <Text style={[styles.stepValue, { color: colors.typography }]}>
+                {midiToLabel(rootMidi)}
+              </Text>
+              <TouchableOpacity
+                onPress={() => stepRoot(1)}
+                disabled={rootMidi >= MAX_ROOT_MIDI}
+                style={[styles.stepBtn, { backgroundColor: colors.neutral300, opacity: rootMidi >= MAX_ROOT_MIDI ? 0.35 : 1 }]}
+                accessibilityLabel={t('practice.keyUp')}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.primary500 }]}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={styles.controlRow}>
+            <Text style={[styles.controlLabel, { color: colors.typography }]}>
+              {t('practice.pace')}
+            </Text>
+            <View style={styles.paceRow}>
+              {PACES.map((p, i) => (
+                <TouchableOpacity
+                  key={p.key}
+                  onPress={() => setPaceIndex(i)}
+                  style={[
+                    styles.paceChip,
+                    {
+                      backgroundColor: i === paceIndex ? colors.primary500 : colors.neutral300
+                    }
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: i === paceIndex }}
+                >
+                  <Text
+                    style={[
+                      styles.paceChipText,
+                      { color: i === paceIndex ? colors.white : colors.typography }
+                    ]}
+                  >
+                    {t(`practice.paces.${p.key}`)}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* ---- Melody list ---- */}
+        {PRACTICE_MELODIES.map((melody) => (
+          <TouchableOpacity
+            key={melody.id}
+            onPress={() => start(melody.id)}
+            style={[
+              styles.card,
+              { backgroundColor: colors.neutral100, borderColor: colors.neutral500 }
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={t('practice.startLabel', { name: melody.name })}
+          >
+            <View style={styles.cardText}>
+              <Text style={[styles.cardTitle, { color: colors.typography }]}>
+                {melody.name}
+              </Text>
+              <Text style={[styles.cardDesc, { color: colors.gray300 }]}>
+                {melody.description}
+              </Text>
+            </View>
+            <Text style={[styles.cardStart, { color: colors.primary500 }]}>
+              {t('practice.start')}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1 },
+  header: { paddingHorizontal: 20, paddingTop: 16, paddingBottom: 8 },
+  heading: { fontSize: 28, fontWeight: '700' },
+  subtitle: { fontSize: 14, marginTop: 2 },
+  scrollContent: { paddingHorizontal: 16, paddingBottom: 40 },
+  controls: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    marginBottom: 20
+  },
+  controlRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 10
+  },
+  controlLabel: { fontSize: 15, fontWeight: '500' },
+  stepper: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  stepBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  stepBtnText: { fontSize: 20, fontWeight: '600' },
+  stepValue: { fontSize: 16, fontWeight: '600', minWidth: 48, textAlign: 'center' },
+  paceRow: { flexDirection: 'row', gap: 8 },
+  paceChip: { paddingHorizontal: 14, paddingVertical: 8, borderRadius: 16 },
+  paceChipText: { fontSize: 13, fontWeight: '600' },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    marginBottom: 12
+  },
+  cardText: { flex: 1, paddingRight: 12 },
+  cardTitle: { fontSize: 17, fontWeight: '600' },
+  cardDesc: { fontSize: 13, marginTop: 4 },
+  cardStart: { fontSize: 15, fontWeight: '700' }
+});
+
+export default PracticeScreen;

--- a/packages/client/src/screens/Practice/PracticeSessionScreen.tsx
+++ b/packages/client/src/screens/Practice/PracticeSessionScreen.tsx
@@ -1,0 +1,218 @@
+/**
+ * PracticeSessionScreen — run one practice take against the chosen melody.
+ *
+ * Drives {@link usePracticeSession}: tap Start → (count-in or play-along) →
+ * record while the target + live pitch scroll in sync on {@link PracticePitchView}
+ * → auto-stop after the melody's length → navigate to Results with the practice
+ * params so scoring targets the same melody.
+ *
+ * The screen owns only the transport timer (auto-stop) and coarse phase UI; the
+ * per-frame pitch never touches React state.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  useWindowDimensions,
+  View
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { findMelody } from 'logic';
+
+import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
+import type { RootStackParamList } from '../../navigation/types';
+import { usePracticeSession } from './usePracticeSession';
+import { PracticePitchView } from './PracticePitchView';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'PracticeSession'>;
+
+const CANVAS_MARGIN = 16;
+const CANVAS_HEIGHT = 260;
+
+export default function PracticeSessionScreen({
+  route,
+  navigation
+}: Props): React.JSX.Element {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { width } = useWindowDimensions();
+  const params = route.params;
+
+  const {
+    phase,
+    targets,
+    durationMs,
+    sharedMidi,
+    sharedFrame,
+    fps,
+    begin,
+    finish,
+    cancel
+  } = usePracticeSession(params);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const melodyName = findMelody(params.melodyId)?.name ?? '';
+
+  const handleStart = useCallback((): void => {
+    setError(null);
+    begin().catch(() => {
+      setError(t('practice.session.micDenied'));
+    });
+  }, [begin, t]);
+
+  const handleCancel = useCallback((): void => {
+    cancel()
+      .catch(() => undefined)
+      .finally(() => navigation.goBack());
+  }, [cancel, navigation]);
+
+  const finishAndGo = useCallback((): void => {
+    finish()
+      .then((handle) => {
+        navigation.replace('Results', { handle, practice: params });
+      })
+      .catch(() => {
+        setError(t('practice.session.failed'));
+      });
+  }, [finish, navigation, params, t]);
+
+  // Stop button: while recording, finish early and score the partial take;
+  // during the count-in, abort back to the picker.
+  const handleStopPress = useCallback((): void => {
+    if (phase === 'recording') {
+      finishAndGo();
+    } else {
+      handleCancel();
+    }
+  }, [phase, finishAndGo, handleCancel]);
+
+  // Auto-stop once the melody's length has elapsed, then go to Results. Stopping
+  // early (manual) flips the phase, which clears this timer via the cleanup.
+  useEffect(() => {
+    if (phase !== 'recording') {
+      return;
+    }
+    const timer = setTimeout(finishAndGo, durationMs);
+    return () => clearTimeout(timer);
+  }, [phase, durationMs, finishAndGo]);
+
+  const isPreparing = phase === 'preparing' || phase === 'countIn';
+
+  return (
+    <SafeAreaView style={[styles.safe, { backgroundColor: colors.neutral300 }]}>
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: colors.typography }]}>{melodyName}</Text>
+        <Text style={[styles.status, { color: colors.gray300 }]}>
+          {phase === 'recording'
+            ? t('practice.session.sing')
+            : isPreparing
+              ? t('practice.session.listen')
+              : phase === 'analyzing'
+                ? t('practice.session.analyzing')
+                : t('practice.session.getReady')}
+        </Text>
+      </View>
+
+      <View
+        style={[
+          styles.canvasWrap,
+          { backgroundColor: colors.neutral50, borderColor: colors.neutral500 }
+        ]}
+      >
+        <PracticePitchView
+          sharedMidi={sharedMidi}
+          sharedFrame={sharedFrame}
+          targets={targets}
+          width={width - 2 * CANVAS_MARGIN}
+          height={CANVAS_HEIGHT}
+          fps={fps}
+        />
+      </View>
+
+      {error ? (
+        <Text style={[styles.error, { color: colors.error }]}>{error}</Text>
+      ) : null}
+
+      <View style={styles.controls}>
+        {phase === 'idle' ? (
+          <TouchableOpacity
+            style={[styles.primaryBtn, { backgroundColor: colors.primary500 }]}
+            onPress={handleStart}
+            accessibilityRole="button"
+            accessibilityLabel={t('practice.session.start')}
+          >
+            <Text style={[styles.primaryBtnText, { color: colors.white }]}>
+              {t('practice.session.start')}
+            </Text>
+          </TouchableOpacity>
+        ) : phase === 'analyzing' ? (
+          <ActivityIndicator color={colors.primary500} />
+        ) : (
+          <TouchableOpacity
+            style={[styles.stopBtn, { borderColor: colors.error }]}
+            onPress={handleStopPress}
+            accessibilityRole="button"
+            accessibilityLabel={t('practice.session.stop')}
+          >
+            <Text style={[styles.stopBtnText, { color: colors.error }]}>
+              {t('practice.session.stop')}
+            </Text>
+          </TouchableOpacity>
+        )}
+
+        {phase === 'idle' ? (
+          <TouchableOpacity
+            style={styles.cancelBtn}
+            onPress={handleCancel}
+            accessibilityRole="button"
+            accessibilityLabel={t('practice.session.back')}
+          >
+            <Text style={[styles.cancelText, { color: colors.gray500 }]}>
+              {t('practice.session.back')}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1 },
+  header: { alignItems: 'center', paddingTop: 16, paddingBottom: 12 },
+  title: { fontSize: 22, fontWeight: '700' },
+  status: { fontSize: 15, marginTop: 4 },
+  canvasWrap: {
+    marginHorizontal: CANVAS_MARGIN,
+    height: CANVAS_HEIGHT,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden'
+  },
+  error: { fontSize: 14, textAlign: 'center', marginTop: 12, marginHorizontal: 16 },
+  controls: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+  primaryBtn: {
+    height: 56,
+    paddingHorizontal: 48,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  primaryBtnText: { fontSize: 18, fontWeight: '700' },
+  stopBtn: {
+    height: 56,
+    paddingHorizontal: 40,
+    borderRadius: 28,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  stopBtnText: { fontSize: 16, fontWeight: '700' },
+  cancelBtn: { paddingVertical: 8 },
+  cancelText: { fontSize: 14, fontWeight: '600' }
+});

--- a/packages/client/src/screens/Practice/__tests__/practiceLayout.test.ts
+++ b/packages/client/src/screens/Practice/__tests__/practiceLayout.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the practice overlay layout math (mirrored by the Skia
+ * worklets). Validates the shared time axis, MIDI→y mapping, and culling.
+ */
+import {
+  midiToY,
+  nowX,
+  pxPerMs,
+  timeToX,
+  visibleTargetSegments,
+  type LayoutConfig
+} from '../practiceLayout';
+
+const CFG: LayoutConfig = {
+  width: 300,
+  height: 200,
+  nowFraction: 0.5,
+  windowMs: 3000,
+  minMidi: 48,
+  maxMidi: 72
+};
+
+describe('time axis', () => {
+  it('places "now" at nowFraction of the width', () => {
+    expect(nowX(CFG)).toBe(150);
+    expect(timeToX(1000, 1000, CFG)).toBe(150); // current time sits at now
+  });
+
+  it('maps past to the left and future to the right of now', () => {
+    const current = 1000;
+    expect(timeToX(0, current, CFG)).toBeLessThan(nowX(CFG)); // 1s ago
+    expect(timeToX(2000, current, CFG)).toBeGreaterThan(nowX(CFG)); // 1s ahead
+  });
+
+  it('scales by a constant px-per-ms', () => {
+    expect(pxPerMs(CFG)).toBeCloseTo(0.1); // 300px / 3000ms
+    // 1000ms ahead of now → +100px.
+    expect(timeToX(2000, 1000, CFG)).toBeCloseTo(250);
+  });
+});
+
+describe('midiToY', () => {
+  it('puts the lowest note at the bottom and highest at the top', () => {
+    expect(midiToY(48, CFG)).toBe(200); // bottom edge
+    expect(midiToY(72, CFG)).toBe(0); // top edge
+  });
+
+  it('clamps out-of-range notes to the edges', () => {
+    expect(midiToY(24, CFG)).toBe(200);
+    expect(midiToY(96, CFG)).toBe(0);
+  });
+});
+
+describe('visibleTargetSegments', () => {
+  const targets = [
+    { midi: 60, startMs: 0, endMs: 500 },
+    { midi: 62, startMs: 500, endMs: 1000 },
+    { midi: 64, startMs: 10_000, endMs: 10_500 } // far future → off-screen
+  ];
+
+  it('returns segments for in-view notes and culls off-screen ones', () => {
+    const segs = visibleTargetSegments(targets, 750, CFG);
+    // The far-future note is culled.
+    expect(segs).toHaveLength(2);
+    for (const s of segs) {
+      expect(s.x2).toBeGreaterThan(s.x1);
+    }
+  });
+
+  it('scrolls left as the transport advances', () => {
+    const early = visibleTargetSegments(targets, 0, CFG)[0];
+    const later = visibleTargetSegments(targets, 500, CFG)[0];
+    expect(later.x1).toBeLessThan(early.x1);
+  });
+});

--- a/packages/client/src/screens/Practice/__tests__/usePracticeSession.test.ts
+++ b/packages/client/src/screens/Practice/__tests__/usePracticeSession.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for usePracticeSession.
+ *
+ * The record controller, reference-tone player, and route detection are mocked,
+ * so we assert the orchestration: target/duration derivation, the play-along
+ * path (headphones → start recording then play the reference), and cancel.
+ * The count-in (speaker) path is timer-driven and covered by inspection.
+ */
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import type { RecordingHandle } from '../../../audio/contract';
+import type { PracticeParams } from '../../../navigation/types';
+
+const HANDLE: RecordingHandle = {
+  id: 'p1',
+  uri: 'file:///mock/p1.wav',
+  sampleRateHz: 44100,
+  durationMs: 3500,
+  samples: []
+};
+
+const mockStart = jest.fn(() => Promise.resolve());
+const mockStop = jest.fn(() => Promise.resolve(HANDLE));
+const controllerState = { isRecording: false };
+
+jest.mock('../../Record/useRecordController', () => ({
+  useRecordController: () => ({
+    sharedPitch: { value: 0 },
+    sharedClarity: { value: 0 },
+    sharedMidi: { value: 0 },
+    sharedCents: { value: 0 },
+    sharedFrame: { value: 0 },
+    start: mockStart,
+    stop: mockStop,
+    get isRecording() {
+      return controllerState.isRecording;
+    },
+    state: 'idle'
+  }),
+  UNVOICED_MIDI: -1
+}));
+
+const mockPlay = jest.fn();
+const mockTonePlayerStop = jest.fn();
+jest.mock('../../../audio/referenceTone', () => ({
+  createReferenceTonePlayer: () => ({ play: mockPlay, stop: mockTonePlayerStop })
+}));
+
+const mockDetectHeadphones = jest.fn();
+jest.mock('../../../audio/outputRoute', () => ({
+  detectHeadphonesConnected: (...a: unknown[]) => mockDetectHeadphones(...a)
+}));
+
+import { usePracticeSession, type UsePracticeSessionValue } from '../usePracticeSession';
+
+const PARAMS: PracticeParams = {
+  melodyId: 'major-scale',
+  rootMidi: 60,
+  noteDurationMs: 500
+};
+
+function Harness({
+  params,
+  onReady
+}: {
+  params: PracticeParams;
+  onReady: (v: UsePracticeSessionValue) => void;
+}): null {
+  onReady(usePracticeSession(params));
+  return null;
+}
+
+function mount(params: PracticeParams = PARAMS): { api: () => UsePracticeSessionValue } {
+  let latest: UsePracticeSessionValue | null = null;
+  void act(() => {
+    TestRenderer.create(
+      React.createElement(Harness, {
+        params,
+        onReady: (v) => {
+          latest = v;
+        }
+      })
+    );
+  });
+  return {
+    api: () => {
+      if (latest === null) {
+        throw new Error('hook did not render');
+      }
+      return latest;
+    }
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  controllerState.isRecording = false;
+});
+
+describe('usePracticeSession derivation', () => {
+  it('builds the melody targets and duration', () => {
+    const { api } = mount();
+    // major-scale has 15 notes at 500ms → 7500ms.
+    expect(api().targets.length).toBe(15);
+    expect(api().durationMs).toBe(7500);
+    expect(api().phase).toBe('idle');
+  });
+
+  it('yields no targets for an unknown melody id', () => {
+    const { api } = mount({ ...PARAMS, melodyId: 'nope' });
+    expect(api().targets).toEqual([]);
+    expect(api().durationMs).toBe(0);
+  });
+});
+
+describe('begin (play-along, headphones present)', () => {
+  it('starts recording then plays the reference along with it', async () => {
+    mockDetectHeadphones.mockResolvedValue(true);
+    const { api } = mount();
+
+    await act(async () => {
+      await api().begin();
+    });
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+    // Reference plays only after recording has started.
+    expect(mockStart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPlay.mock.invocationCallOrder[0]
+    );
+    expect(api().phase).toBe('recording');
+  });
+
+  it('surfaces a permission rejection and returns to idle', async () => {
+    mockDetectHeadphones.mockResolvedValue(true);
+    mockStart.mockRejectedValueOnce(new Error('denied'));
+    const { api } = mount();
+
+    await act(async () => {
+      await expect(api().begin()).rejects.toThrow('denied');
+    });
+    expect(api().phase).toBe('idle');
+  });
+});
+
+describe('finish + cancel', () => {
+  it('finish stops the engine and returns the handle', async () => {
+    mockDetectHeadphones.mockResolvedValue(true);
+    const { api } = mount();
+    await act(async () => {
+      await api().begin();
+    });
+
+    let handle: RecordingHandle | null = null;
+    await act(async () => {
+      handle = await api().finish();
+    });
+    expect(handle).toEqual(HANDLE);
+    expect(mockTonePlayerStop).toHaveBeenCalled();
+  });
+
+  it('cancel stops the reference and engine while recording', async () => {
+    controllerState.isRecording = true;
+    const { api } = mount();
+    await act(async () => {
+      await api().cancel();
+    });
+    expect(mockTonePlayerStop).toHaveBeenCalled();
+    expect(mockStop).toHaveBeenCalled();
+    expect(api().phase).toBe('idle');
+  });
+});

--- a/packages/client/src/screens/Practice/practiceLayout.ts
+++ b/packages/client/src/screens/Practice/practiceLayout.ts
@@ -1,0 +1,76 @@
+/**
+ * practiceLayout — pure positioning math for the practice target+live overlay.
+ *
+ * Both layers share one time axis: a "now" marker sits at `nowFraction` of the
+ * width; the visible window spans `windowMs`, so px-per-ms is constant and any
+ * timestamp maps to an x. The Skia worklets in PracticePitchView inline these
+ * exact formulas (Reanimated worklets can't call across modules), so this module
+ * exists to unit-test the math the worklets mirror. Keep them in lock-step.
+ */
+import type { TargetNote } from 'logic';
+
+export interface LayoutConfig {
+  /** Canvas width in px. */
+  width: number;
+  /** Canvas height in px. */
+  height: number;
+  /** Horizontal position of "now", 0..1 (e.g. 0.6 → past left, future right). */
+  nowFraction: number;
+  /** Total time span visible across the width, in ms. */
+  windowMs: number;
+  /** Lowest MIDI note mapped to the bottom edge. */
+  minMidi: number;
+  /** Highest MIDI note mapped to the top edge. */
+  maxMidi: number;
+}
+
+/** Pixels per millisecond across the window. */
+export function pxPerMs(cfg: LayoutConfig): number {
+  return cfg.width / cfg.windowMs;
+}
+
+/** The x of the "now" marker. */
+export function nowX(cfg: LayoutConfig): number {
+  return cfg.width * cfg.nowFraction;
+}
+
+/** Map an absolute time (ms) to an x, given the current transport time. */
+export function timeToX(timeMs: number, currentMs: number, cfg: LayoutConfig): number {
+  return nowX(cfg) + (timeMs - currentMs) * pxPerMs(cfg);
+}
+
+/** Map a MIDI note to a y (clamped to the canvas; higher note → higher up). */
+export function midiToY(midi: number, cfg: LayoutConfig): number {
+  const span = Math.max(1, cfg.maxMidi - cfg.minMidi);
+  const norm = (midi - cfg.minMidi) / span;
+  const clamped = norm < 0 ? 0 : norm > 1 ? 1 : norm;
+  return cfg.height - clamped * cfg.height;
+}
+
+export interface TargetSegment {
+  x1: number;
+  x2: number;
+  y: number;
+}
+
+/**
+ * The on-canvas segments for the target notes currently in view, given the
+ * transport time. Off-screen notes (entirely left or right of the canvas) are
+ * culled.
+ */
+export function visibleTargetSegments(
+  targets: readonly TargetNote[],
+  currentMs: number,
+  cfg: LayoutConfig
+): TargetSegment[] {
+  const out: TargetSegment[] = [];
+  for (const t of targets) {
+    const x1 = timeToX(t.startMs, currentMs, cfg);
+    const x2 = timeToX(t.endMs, currentMs, cfg);
+    if (x2 < 0 || x1 > cfg.width) {
+      continue;
+    }
+    out.push({ x1, x2, y: midiToY(t.midi, cfg) });
+  }
+  return out;
+}

--- a/packages/client/src/screens/Practice/usePracticeSession.ts
+++ b/packages/client/src/screens/Practice/usePracticeSession.ts
@@ -1,0 +1,156 @@
+/**
+ * usePracticeSession — orchestrates one practice take against a target melody.
+ *
+ * Wraps {@link useRecordController} (engine + shared values + machine) and adds:
+ *   - building the `TargetNote[]` from the chosen catalogue melody;
+ *   - the reference presentation, chosen by the audio route:
+ *       headphones → play-along (reference plays WHILE recording);
+ *       speaker    → count-in (preview the melody once, then record in silence);
+ *   - phase reporting for the UI.
+ *
+ * The per-frame pitch stream still flows only through the controller's shared
+ * values (UI thread) — this hook adds no per-frame work. Auto-stop after the
+ * melody's length is left to the screen (it owns the transport timer), keeping
+ * this hook free of timer/teardown races.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { findMelody, melodyDurationMs, type TargetNote } from 'logic';
+import { type SharedValue } from 'react-native-reanimated';
+
+import { createReferenceTonePlayer } from '../../audio/referenceTone';
+import { detectHeadphonesConnected } from '../../audio/outputRoute';
+import {
+  DEFAULT_ENGINE_CONFIG,
+  type RecordingHandle
+} from '../../audio/contract';
+import type { PracticeParams } from '../../navigation/types';
+import { useRecordController } from '../Record/useRecordController';
+
+export type PracticePhase =
+  | 'idle'
+  | 'preparing'
+  | 'countIn'
+  | 'recording'
+  | 'analyzing';
+
+export interface UsePracticeSessionValue {
+  phase: PracticePhase;
+  /** The reference melody being practised. */
+  targets: TargetNote[];
+  /** Length of the melody (and so the recording), in ms. */
+  durationMs: number;
+  /** Transport clock (frames) + latest pitch, for the overlay (UI thread). */
+  sharedMidi: SharedValue<number>;
+  sharedFrame: SharedValue<number>;
+  /** Frames/sec the transport advances at (the engine emit rate). */
+  fps: number;
+  /**
+   * Run the pre-roll (count-in or, with headphones, nothing) and start
+   * recording. Resolves once recording has begun; rejects if mic permission is
+   * denied. The screen stops the take after {@link durationMs}.
+   */
+  begin(): Promise<void>;
+  /** Stop the engine and resolve the finished capture for analysis. */
+  finish(): Promise<RecordingHandle>;
+  /** Abort the session (stop reference + engine) and return to idle. */
+  cancel(): Promise<void>;
+}
+
+/** Silent gap between the count-in preview and the start of recording. */
+const COUNT_IN_GAP_MS = 600;
+
+/** A simple cancellable delay. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function usePracticeSession(
+  params: PracticeParams
+): UsePracticeSessionValue {
+  const { melodyId, rootMidi, noteDurationMs } = params;
+  const controller = useRecordController();
+
+  const targets = useMemo<TargetNote[]>(() => {
+    const melody = findMelody(melodyId);
+    return melody ? melody.build({ rootMidi, noteDurationMs }) : [];
+  }, [melodyId, rootMidi, noteDurationMs]);
+
+  const durationMs = useMemo(() => melodyDurationMs(targets), [targets]);
+
+  const playerRef = useRef(createReferenceTonePlayer());
+  const cancelledRef = useRef(false);
+  const [phase, setPhase] = useState<PracticePhase>('idle');
+
+  const begin = useCallback(async (): Promise<void> => {
+    cancelledRef.current = false;
+    const player = playerRef.current;
+    setPhase('preparing');
+
+    try {
+      const headphones = await detectHeadphonesConnected();
+      if (cancelledRef.current) {
+        return;
+      }
+
+      if (!headphones) {
+        // Speaker: preview the whole melody, then a short silence, then record.
+        setPhase('countIn');
+        player.play(targets);
+        await wait(durationMs + COUNT_IN_GAP_MS);
+        player.stop();
+        if (cancelledRef.current) {
+          return;
+        }
+      }
+
+      setPhase('recording');
+      await controller.start();
+
+      if (headphones) {
+        // Headphones: the reference plays along while recording (the mic won't
+        // pick it up), so the singer can follow in real time.
+        player.play(targets);
+      }
+    } catch (error) {
+      player.stop();
+      setPhase('idle');
+      throw error;
+    }
+  }, [controller, targets, durationMs]);
+
+  const finish = useCallback(async (): Promise<RecordingHandle> => {
+    playerRef.current.stop();
+    setPhase('analyzing');
+    const handle = await controller.stop();
+    setPhase('idle');
+    return handle;
+  }, [controller]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    cancelledRef.current = true;
+    playerRef.current.stop();
+    if (controller.isRecording) {
+      try {
+        await controller.stop();
+      } catch {
+        // Already stopped / never started — nothing to clean up.
+      }
+    }
+    setPhase('idle');
+  }, [controller]);
+
+  return {
+    phase,
+    targets,
+    durationMs,
+    sharedMidi: controller.sharedMidi,
+    sharedFrame: controller.sharedFrame,
+    fps: DEFAULT_ENGINE_CONFIG.emitRateHz,
+    begin,
+    finish,
+    cancel
+  };
+}
+
+export default usePracticeSession;

--- a/packages/client/src/screens/Results/NoteList.tsx
+++ b/packages/client/src/screens/Results/NoteList.tsx
@@ -7,13 +7,22 @@
  * here. A `FlatList` keeps long takes cheap to scroll.
  */
 import React, { useCallback } from 'react';
-import { FlatList, StyleSheet, Text, View, type ListRenderItemInfo } from 'react-native';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ListRenderItemInfo
+} from 'react-native';
 import { NOTE_NAMES, type NoteEvent } from 'logic';
 
 import { useTheme } from '../../theme';
 
 export interface NoteListProps {
   notes: NoteEvent[];
+  /** When provided, each row is tappable and calls this with the note's MIDI. */
+  onPressNote?: (midi: number) => void;
 }
 
 /** Scientific-pitch label for a MIDI note number, e.g. 69 → "A4". */
@@ -27,21 +36,19 @@ function formatTime(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-export function NoteList({ notes }: NoteListProps) {
+export function NoteList({ notes, onPressNote }: NoteListProps) {
   const { colors } = useTheme();
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<NoteEvent>) => {
       const cents = Math.round(item.cents);
       const centsLabel = cents === 0 ? '±0' : cents > 0 ? `+${cents}` : `${cents}`;
-      return (
-        <View
-          style={[styles.row, { borderBottomColor: colors.neutral500 }]}
-          accessibilityRole="text"
-          accessibilityLabel={`Note ${index + 1}: ${midiToLabel(item.midi)}, ${Math.round(
-            item.durationMs
-          )} milliseconds, ${centsLabel} cents`}
-        >
+      const tappable = onPressNote != null;
+      const label = `Note ${index + 1}: ${midiToLabel(item.midi)}, ${Math.round(
+        item.durationMs
+      )} milliseconds, ${centsLabel} cents${tappable ? ', tap to hear' : ''}`;
+      const cells = (
+        <>
           <Text style={[styles.name, { color: colors.typography }]}>
             {midiToLabel(item.midi)}
           </Text>
@@ -52,10 +59,32 @@ export function NoteList({ notes }: NoteListProps) {
             {Math.round(item.durationMs)} ms
           </Text>
           <Text style={[styles.cents, { color: colors.gray300 }]}>{centsLabel}¢</Text>
+        </>
+      );
+
+      if (tappable) {
+        return (
+          <TouchableOpacity
+            style={[styles.row, { borderBottomColor: colors.neutral500 }]}
+            onPress={() => onPressNote(item.midi)}
+            accessibilityRole="button"
+            accessibilityLabel={label}
+          >
+            {cells}
+          </TouchableOpacity>
+        );
+      }
+      return (
+        <View
+          style={[styles.row, { borderBottomColor: colors.neutral500 }]}
+          accessibilityRole="text"
+          accessibilityLabel={label}
+        >
+          {cells}
         </View>
       );
     },
-    [colors]
+    [colors, onPressNote]
   );
 
   if (notes.length === 0) {

--- a/packages/client/src/screens/Results/ResultsScreen.tsx
+++ b/packages/client/src/screens/Results/ResultsScreen.tsx
@@ -9,28 +9,57 @@
  *
  * See docs/NATIVE_BUILD_PLAN.md §3 (WP-RESULTS-UI).
  */
-import React from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-import type { PitchScore } from 'logic';
+import { findMelody, type PitchScore, type TargetNote } from 'logic';
 
 import type { RootStackParamList } from '../../navigation/types';
 import { useTheme } from '../../theme';
+import { createReferenceTonePlayer } from '../../audio/referenceTone';
 import { ExportSheet } from './ExportSheet';
 import { FeedbackCard } from './FeedbackCard';
 import { NoteList } from './NoteList';
 import { ScoreCard } from './ScoreCard';
 import { useResults } from './useResults';
 
+/** How long a tapped reference note sounds, in ms. */
+const TAP_NOTE_MS = 700;
+
 type Props = NativeStackScreenProps<RootStackParamList, 'Results'>;
 
 export default function ResultsScreen({ route }: Props) {
   const { colors } = useTheme();
-  const { handle } = route.params;
+  const { handle, practice } = route.params;
 
-  const { notes, feedback, midiUri, recording } = useResults(handle);
+  // For a practice take, rebuild the reference melody so scoring + per-note
+  // feedback target it (rather than the take itself).
+  const targets = useMemo<TargetNote[] | undefined>(() => {
+    if (!practice) {
+      return undefined;
+    }
+    const melody = findMelody(practice.melodyId);
+    return melody
+      ? melody.build({
+          rootMidi: practice.rootMidi,
+          noteDurationMs: practice.noteDurationMs
+        })
+      : undefined;
+  }, [practice]);
+
+  const { notes, feedback, midiUri, recording } = useResults(handle, { targets });
   const title = recording?.title ?? 'Take';
+
+  // Tap a note to hear its true pitch (reuses the practice reference-tone player).
+  const tonePlayer = useMemo(() => createReferenceTonePlayer(), []);
+  useEffect(() => () => tonePlayer.stop(), [tonePlayer]);
+  const playNote = useCallback(
+    (midi: number) => {
+      tonePlayer.play([{ midi, startMs: 0, endMs: TAP_NOTE_MS }]);
+    },
+    [tonePlayer]
+  );
 
   // ScoreCard renders the same frame-level pitch numbers `computeFeedback`
   // already derived — adapt the FeedbackDto to the `PitchScore` shape it expects
@@ -56,8 +85,10 @@ export default function ResultsScreen({ route }: Props) {
         <FeedbackCard feedback={feedback} />
 
         <View style={styles.listWrap}>
-          <Text style={[styles.sectionTitle, { color: colors.gray500 }]}>Notes</Text>
-          <NoteList notes={notes} />
+          <Text style={[styles.sectionTitle, { color: colors.gray500 }]}>
+            Notes (tap to hear)
+          </Text>
+          <NoteList notes={notes} onPressNote={playNote} />
         </View>
 
         <ExportSheet midiUri={midiUri} title={title} />

--- a/packages/client/src/screens/Results/useResults.ts
+++ b/packages/client/src/screens/Results/useResults.ts
@@ -26,7 +26,8 @@ import {
   notesToMidi,
   segmentNotes,
   smoothPitch,
-  type NoteEvent
+  type NoteEvent,
+  type TargetNote
 } from 'logic';
 import type { FeedbackDto, RecordingDto } from 'shared';
 
@@ -66,14 +67,22 @@ export interface UseResultsOptions {
   createdAtMs?: number;
   /** When false, skip cloud persistence / MIDI-write entirely (analysis still runs). */
   persist?: boolean;
+  /**
+   * Reference melody this take was sung against (practice mode). When present,
+   * scoring + per-note feedback target this melody instead of the take itself.
+   */
+  targets?: readonly TargetNote[];
 }
 
 /** Pure: run the offline pipeline + feedback synthesis over a handle's samples. */
-export function analyzeHandle(handle: RecordingHandle): ResultsAnalysis {
+export function analyzeHandle(
+  handle: RecordingHandle,
+  targets?: readonly TargetNote[]
+): ResultsAnalysis {
   const smoothed = smoothPitch(handle.samples);
   const notes = segmentNotes(smoothed);
   const midi = notesToMidi(notes);
-  const feedback = computeFeedback(handle);
+  const feedback = computeFeedback(handle, targets);
   return { notes, midi, feedback };
 }
 
@@ -90,11 +99,12 @@ export function useResults(
   handle: RecordingHandle,
   options: UseResultsOptions = {}
 ): UseResultsValue {
-  const { title, createdAtMs, persist = true } = options;
+  const { title, createdAtMs, persist = true, targets } = options;
 
   const analysis = useMemo(
-    () => analyzeHandle(handle),
-    // Analysis is a pure function of the handle's frames.
+    () => analyzeHandle(handle, targets),
+    // Analysis is a pure function of the handle's frames + the chosen melody;
+    // a take's id is unique per capture, so it keys both safely.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [handle.id]
   );

--- a/packages/logic/src/melodies.ts
+++ b/packages/logic/src/melodies.ts
@@ -104,3 +104,11 @@ export const PRACTICE_MELODIES: readonly PracticeMelody[] = [
 export function findMelody(id: string): PracticeMelody | undefined {
   return PRACTICE_MELODIES.find((m) => m.id === id);
 }
+
+/**
+ * Total length of a built melody in ms (the end of its last note), or 0 for an
+ * empty target list. Drives the practice transport (how long to record).
+ */
+export function melodyDurationMs(targets: readonly TargetNote[]): number {
+  return targets.length === 0 ? 0 : targets[targets.length - 1].endMs;
+}


### PR DESCRIPTION
Builds the practice loop end-to-end from the agreed UX spec (the "missing half" of the product loop — sing *against* a target).

## Spec (from the product Q&A)
| Decision | Choice |
|---|---|
| Entry point | Dedicated **Practice tab** |
| Reference audio | **Adaptive**: play-along on headphones, else count-in then silence |
| Live visuals | **Target + live pitch line, scrolling in sync** |
| Scoring | **Fixed timeline** (absolute time) |
| Catalogue | **Built-in exercises** only (v1) |

## Flow
- **Practice tab** (`PracticeScreen`): pick an exercise + key + pace.
- **PracticeSession**: route-adaptive reference (play-along through headphones so the mic doesn't capture it, otherwise a count-in preview then silent record) while the target melody and the live sung pitch scroll together on a Skia canvas (`PracticePitchView`) sharing the `sharedFrame` transport clock. Auto-stops after the melody's length; stop early to score the partial take.
- **Results**: scores the take against the chosen melody (per-target feedback), not against itself.

## Pieces
- `logic/melodies.ts`: `melodyDurationMs` helper (catalogue already existed).
- `audio/outputRoute.ts`: pluggable headphone detection with a safe count-in default.
- `analysis/feedback.ts`: `computeFeedback(handle, targets?)` scores against an external melody + per-target feedback; `useResults` threads targets through.
- `screens/Practice/`: `practiceLayout` (pure overlay math), `PracticePitchView`, `usePracticeSession`, `PracticeScreen`, `PracticeSessionScreen`.
- Navigation: Practice tab + `PracticeSession` route + `practice` param on Results.

## Also (same Q&A)
- **Results**: tap a note to hear its reference pitch (reuses `referenceTone`).
- **Auth**: `resetPassword` + a "Forgot password?" affordance on Login.

## Tests
Melody/overlay layout math, output-route fallbacks, target-aware feedback, the practice session controller (play-along / finish / cancel), and `resetPassword`.

## Still open
Tracked in `docs/OPEN_QUESTIONS.md`: wiring a **native headphone-route probe** (detection is pluggable but defaults to count-in until wired), remote/imported catalogue, rubato/time-aligned scoring, and the `delete_account` RPC privilege check. As with prior work, the client suite can't run here (no lockfile) and there's no device build — logic is verified by reasoning + the pure-unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_