### PR TITLE
docs: design the Notes + Dashboard module (next build)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -40,6 +40,8 @@ merged to `main` unless marked **Phase V** (needs a real dev machine) or
 - `docs/NATIVE_SETUP.md` — **the Phase V runbook** (pod install, Gradle, Xcode steps).
 - `docs/DEPLOYMENT.md` — signing, secrets matrix, release runbook.
 - `docs/AUDIT_FINDINGS.md` — cleanliness audit results + deferred items.
+- `docs/OPEN_QUESTIONS.md` — parked product-UX decisions.
+- **`docs/NOTES_MODULE_DESIGN.md` — the NEXT build: Notes + Dashboard module (see §8).**
 - `docs/OPEN_QUESTIONS.md` — parked product-UX decisions (practice mode, sharing).
 
 ---
@@ -149,8 +151,9 @@ Still deferred (small, non-blocking):
 
 ## 6. Workflow / repo conventions
 
-- **Dev branch:** `claude/latest-repo-changes-vip5ss` (currently reset onto merged
-  `main` @ `2af3da2`). Merged PRs are final; start follow-up work fresh off `main`.
+- **Dev branch:** `claude/latest-repo-changes-vip5ss`, always reset onto the latest
+  merged `main` before new work. Merged PRs are final; start follow-up work fresh
+  off `main` (force-with-lease the branch when it only carries already-merged history).
 - **Merges:** repo disallows merge commits → use **squash**.
 - Monorepo: Yarn 3 (Berry), `nodeLinker: node-modules`, Corepack. Packages:
   `client` (RN app), `logic`, `shared`. (The Express `server` and the orphaned
@@ -161,10 +164,36 @@ Still deferred (small, non-blocking):
 
 ## 7. Suggested next steps (when you resume)
 
-1. **Phase V** (a few hours on a Mac): regenerate the lockfile, `pod install` +
-   Xcode wiring, Gradle, provision Supabase, boot on a device. This turns the
-   scaffold into a running app and flips CI fully green incl. the client suite.
-2. Then knock out the deferred cleanups (§4 items 1–4) — small, CI-validatable.
-3. Then build the **reference-tone / target-melody** feature — it's the missing
-   half of the product loop (sing *against* a target), and the scoring path
-   already supports it.
+1. **Build the Notes + Dashboard module** — the designed next feature; full spec in
+   `docs/NOTES_MODULE_DESIGN.md` (and §8 below). This is the planned next session.
+2. **Phase V** (a few hours on a Mac): regenerate the lockfile, `pod install` +
+   Xcode wiring, Gradle, provision Supabase, boot on a device. Turns the scaffold
+   into a running app and flips CI fully green incl. the client suite.
+
+*(Practice / target-melody mode and the account/profile features are already
+built and merged — see §1.)*
+
+---
+
+## 8. Next build — Notes + Dashboard (designed, not yet built)
+
+Full spec: **`docs/NOTES_MODULE_DESIGN.md`**. What the next session does:
+
+- **Reframe freeform recording as "Notes."** The old **Record + Library** tabs
+  collapse into one **Notes** surface (capture a sung idea → analyse → keep). The
+  per-take self-score logic is **kept but reframed as descriptive analysis**
+  (key/tempo/range/steadiness), not a grade.
+- **Continual on-device pattern analysis** over the notes corpus: most/least-sung
+  **intervals**, recurring **fragments** (interval n-grams), and **chord-change
+  reflection** (implied harmony, tuneable). "Most avoided" = patterns *furthest*
+  from the user's common-pattern centroid.
+- **New `Dashboard` tab**: training-progress trajectory + most-common + most-avoided
+  patterns.
+- **IA → 3 tabs**: **Practice · Notes · Dashboard**. Profile + Settings merge into a
+  single **Account & Settings** screen reached from a header button.
+- **Data**: replace `recordings` with `notes` (adds `melody_json` so analysis is
+  pure-data) + a lightweight `practice_progress` table (trajectory only, no audio —
+  practice takes themselves are not kept).
+- Compute is **on-device, recomputed on change** (no server job).
+
+Decisions are locked in `docs/NOTES_MODULE_DESIGN.md` §2; build order in §10.

--- a/docs/NOTES_MODULE_DESIGN.md
+++ b/docs/NOTES_MODULE_DESIGN.md
@@ -1,0 +1,200 @@
+# micdrp — Notes + Dashboard module (design / build spec)
+
+Spec for the next build session. Reframes freeform recording as **Notes**, adds
+continual on-device pattern analysis over the notes corpus, and a **Dashboard**
+that visualizes training progress and the user's melodic/harmonic tendencies.
+Consolidates the app to **3 tabs** + a header-accessed **Account & Settings**
+screen. Yolo mode (single dev, no users): replace, don't migrate.
+
+---
+
+## 1. Intent
+
+A **note** is a sung musical-idea memo: you sing something, it's saved and
+analysed. The system continually mines the corpus of notes to answer:
+- which **intervals** do I sing most / avoid?
+- which **melodic fragments** recur most?
+- which **chord changes** do my melodies reflect most?
+- (Dashboard) how is my **training** (Practice) trending over time?
+
+This is the missing "understand my own voice" half of the app, distinct from
+Practice (target-driven training).
+
+---
+
+## 2. Key decisions (confirmed)
+
+| Topic | Decision |
+|---|---|
+| Freeform recording | **Is** the Notes idea. Collapse the old **Record + Library** tabs into a single **Notes** surface. |
+| Self-score logic | **Keep it, reframe as analysis** — the per-note metrics (key, tempo, range, intonation steadiness) are descriptive analysis of a note, not a grade. No "score / 100" headline. |
+| Corpus | The user's **notes** only. Practice takes are excluded (they're target melodies, not the user's ideas). |
+| Practice takes | **Don't keep the takes** (no audio/full record). **Keep the progress trajectory** — one lightweight metrics row per practice session, for the Dashboard. |
+| v1 insights | **All three**: interval histogram, frequent fragments, chord-change reflection. |
+| Chord inference | **Infer from the melody**, and make it **tuneable** (window, vocabulary, key-relative, min-confidence). |
+| Compute | **On-device, recomputed on change**; persist each note's symbolic melody so re-aggregation never re-touches audio. |
+| "Most avoided" | Patterns **harmonically furthest from the user's most-common patterns** (max distance from the common-pattern centroid), not merely least-frequent. |
+
+---
+
+## 3. Information architecture (changes the merged app)
+
+Tabs collapse from 5 → **3**:
+
+| Was | Now |
+|---|---|
+| Record (freeform, self-scored) + Library | **Notes** — capture, list, per-note analysis, playback |
+| Practice | **Practice** — unchanged capture; now writes a progress row instead of a full recording |
+| Profile + Settings (two tabs) | **Account & Settings** — one screen, reached via a **header button** on each tab |
+| — | **Dashboard** — training progress + common patterns + avoided patterns |
+
+Result: **Practice · Notes · Dashboard** tabs, plus a header gear/avatar →
+**Account & Settings**.
+
+---
+
+## 4. Data model (Supabase)
+
+Replace the generic `recordings` table with two purpose-built tables.
+
+### `notes` (the corpus)
+```
+notes(
+  id uuid pk,
+  user_id uuid -> auth.users on delete cascade,
+  created_at timestamptz default now(),
+  title text,
+  duration_ms int,
+  sample_rate_hz int,
+  audio_path text,                 -- blob in storage (reuse 'takes' bucket or rename 'notes')
+  melody_json jsonb not null,      -- NoteEvent[] (the symbolic melody; source of truth for analysis)
+  key text,
+  tempo_bpm numeric,
+  -- reframed self-analysis (descriptive, not a grade):
+  in_tune_ratio numeric,
+  mean_cents_error numeric,
+  note_count int,
+  range_low_midi int,
+  range_high_midi int
+)
+```
+Owner-scoped RLS exactly like the current `recordings` policies. `melody_json`
+is what makes corpus analysis pure-data (no DSP re-run).
+
+### `practice_progress` (trajectory only — no audio)
+```
+practice_progress(
+  id uuid pk,
+  user_id uuid -> auth.users on delete cascade,
+  created_at timestamptz default now(),
+  melody_id text,
+  root_midi int,
+  note_duration_ms int,
+  score numeric,
+  in_tune_ratio numeric,
+  mean_cents_error numeric,
+  evaluated_frames int
+)
+```
+One row per finished practice session. Powers the Dashboard trend. Practice no
+longer persists a recording/audio.
+
+> Migration is a clean rewrite of `supabase/migrations/0001_init.sql` (no users):
+> drop `recordings`, add `notes` + `practice_progress`. Update the `Database`
+> type in `lib/supabase.ts`. Keep the `delete_account` RPC (now cascades both).
+
+---
+
+## 5. Analysis (`logic` — pure, dependency-free, unit-tested)
+
+The heavy DSP already ran at capture; this is cheap symbolic math.
+
+- `melodyToIntervals(NoteEvent[]) → number[]` — consecutive signed semitone
+  deltas (transposition-invariant).
+- `intervalHistogram(corpus: number[][]) → Map<intervalName, count>` — directional
+  (up/down) and folded interval-class counts; named (m2, M2, m3, …, P5, …).
+- `frequentFragments(corpus, { nRange: [3,5] }) → { intervals, count, example }[]` —
+  top recurring interval n-grams, each with a representative pitch realization
+  (playable via `referenceTone`).
+- `impliedHarmony(NoteEvent[], opts) → { startMs, endMs, chord, confidence }[]` —
+  per-window chord estimate via key/chord-template matching (reuse the
+  Krumhansl-Schmuckler machinery in `logic/key.ts`). **Tuneable** `opts`:
+  `windowMs`, `vocabulary: 'triads' | 'sevenths'`, `keyRelative: boolean`,
+  `minConfidence: number`.
+- `chordReflection(corpus, opts) → { change, count }[]` — which chords / chord
+  changes the melodies most reflect.
+- `avoidanceProfile(corpus, vocabulary) → { pattern, distance }[]` — patterns
+  **furthest** from the centroid of the user's common patterns (define a distance
+  over interval / pitch-class vectors). This is "most avoided."
+
+All consume `melody_json` from the notes cache; no audio.
+
+---
+
+## 6. Notes tab
+
+- **Capture**: reuse `useRecordController` + `smoothPitch → segmentNotes`; **no
+  score gate**. Save → `notesRepo.create({ audioUri, melody, analysis, title? })`.
+- **List**: replaces Library — notes newest-first, playback, swipe-delete.
+- **Detail**: the reframed analysis (key, tempo, range, steadiness, note list),
+  tap-a-note-to-hear (existing `referenceTone`), MIDI export (existing).
+- `computeFeedback` is reused but **relabelled** — surface the metrics as
+  "analysis," drop the headline score number.
+
+---
+
+## 7. Dashboard tab
+
+Three sections:
+1. **Training progress** — trajectory from `practice_progress` (score / in-tune
+   ratio over time; optional per-melody filter).
+2. **Most common patterns** — top intervals, fragments, chord reflections from the
+   notes corpus.
+3. **Most avoided patterns** — from `avoidanceProfile` (furthest from common).
+
+Charts: start with lightweight RN/Skia views (no heavy chart dependency unless it
+proves needed).
+
+---
+
+## 8. Account & Settings (consolidated)
+
+One screen merging the current Profile + Settings:
+- Account: display name, email, password reset, sign out, delete account.
+- Engine tuning, theme.
+- **Chord-inference tuning knobs**: `windowMs`, vocabulary (triads / 7ths),
+  key-relative, min-confidence.
+- About.
+
+Reached via a header button (gear/avatar) on each tab; no longer tabs.
+
+---
+
+## 9. Compute model
+
+On-device. Notes-corpus aggregates recompute when notes change (cheap). Practice
+appends a progress row per session. Optionally cache the latest aggregate summary
+in MMKV for instant Dashboard open. No server/background job (cross-device
+aggregation is deferred).
+
+---
+
+## 10. Build order (next session)
+
+1. **Schema**: rewrite migration → `notes` + `practice_progress`; `notesRepo` +
+   `practiceProgressRepo`; update `Database` type.
+2. **logic**: intervals / histogram / fragments / impliedHarmony / chordReflection
+   / avoidance + tests (pure, CI-green).
+3. **Notes tab**: capture (reframed Record) + list + detail + playback.
+4. **Practice**: write a `practice_progress` row on finish (drop full-recording save).
+5. **Dashboard tab**: progress + common + avoided.
+6. **Account & Settings**: consolidate Profile + Settings; header nav button.
+7. **Cleanup/i18n**: remove Record + Library tabs and the old `recordings` path;
+   3-tab navigator; new i18n keys.
+
+## 11. Deferred / open
+
+- Cross-device (server-side) aggregation — on-device only for now.
+- Chart visual design.
+- Note tagging / titling / folders.
+- Whether to keep a MIDI/file **import** path for notes (currently sung-only).


### PR DESCRIPTION
Captures the clarified spec for the next build session — **no code yet**, just the design.

Adds **`docs/NOTES_MODULE_DESIGN.md`** and points `docs/HANDOFF.md` §8 at it.

## Decisions
- **Reframe freeform recording as "Notes."** Collapse the **Record + Library** tabs into one **Notes** surface. The per-take self-score logic is **kept but reframed as descriptive analysis** (key / tempo / range / steadiness), not a grade.
- **Corpus = the user's notes** (practice takes excluded).
- **Continual on-device analysis** over the notes corpus: interval histogram, frequent fragments (transposition-invariant interval n-grams), and **chord-change reflection** via tuneable implied-harmony inference. **"Most avoided" = patterns furthest from the user's common-pattern centroid** (not merely least-frequent).
- **New `Dashboard` tab**: training-progress trajectory + most-common + most-avoided patterns.
- **IA → 3 tabs**: **Practice · Notes · Dashboard**. Profile + Settings merge into a single **Account & Settings** screen reached from a header button.
- **Data**: replace `recordings` with `notes` (adds `melody_json` so analysis is pure-data) + a lightweight `practice_progress` table (trajectory only — practice takes themselves aren't kept).
- **Compute**: on-device, recomputed on change (no server job).

Build order is in `NOTES_MODULE_DESIGN.md` §10 so the next session can start straight from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLwphkozHZxUNfhv4eaYu)_