### PR TITLE
fix(client): UX audit fixes — dark mode, Results i18n, safe delete, splash & error recovery

### DIFF
--- a/packages/client/App.tsx
+++ b/packages/client/App.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import AppProviders from './src/app/providers';
 import RootNavigator from './src/navigation/RootNavigator';
+import ErrorBoundary from './src/screens/ErrorBoundary';
 
 export default function App() {
   return (
     <AppProviders>
-      <RootNavigator />
+      <ErrorBoundary>
+        <RootNavigator />
+      </ErrorBoundary>
     </AppProviders>
   );
 }

--- a/packages/client/jest.setup.js
+++ b/packages/client/jest.setup.js
@@ -91,7 +91,15 @@ jest.mock('@shopify/react-native-skia', () => {
     Rect: noop,
     Text: noop,
     Skia: {
-      Path: { Make: () => ({ moveTo() {}, lineTo() {}, reset() {}, close() {} }) }
+      Path: {
+        Make: () => ({ moveTo() {}, lineTo() {}, reset() {}, close() {} }),
+        MakeFromSVGString: () => ({
+          moveTo() {},
+          lineTo() {},
+          reset() {},
+          close() {}
+        })
+      }
     },
     useFont: () => null,
     vec: (x, y) => ({ x, y })

--- a/packages/client/src/components/Icon.tsx
+++ b/packages/client/src/components/Icon.tsx
@@ -1,0 +1,72 @@
+/**
+ * Icon — vector icons drawn with Skia from SVG path data.
+ *
+ * Every glyph is a 24×24 SVG path string rendered through the Skia canvas that
+ * already powers the app's visuals. This keeps icons resolution-independent and,
+ * crucially, fully shippable over-the-air: there are no native vector drawables,
+ * asset catalogues, or font files to rebuild — changing or adding an icon is a
+ * pure-JS bundle change.
+ *
+ * Replaces the previous text-glyph approach (e.g. a "⚙︎" rendered as <Text/>),
+ * which rendered inconsistently across platforms and fonts.
+ */
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { Canvas, Group, Path, Skia } from '@shopify/react-native-skia';
+
+export type IconName =
+  | 'mic'
+  | 'practice'
+  | 'notes'
+  | 'dashboard'
+  | 'settings';
+
+/** Material-style filled glyphs, authored on a 24×24 viewbox. */
+const ICON_PATHS: Record<IconName, string> = {
+  // Microphone — used for the app mark / practice tab.
+  mic: 'M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5-3c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z',
+  practice:
+    'M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5-3c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z',
+  // Single eighth-note — the Notes tab.
+  notes:
+    'M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z',
+  // Ascending bars — the Dashboard tab.
+  dashboard: 'M4 9h4v11H4zm6-5h4v16h-4zm6 8h4v8h-4z',
+  // Cog — Account & Settings.
+  settings:
+    'M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z'
+};
+
+const VIEWBOX = 24;
+
+export interface IconProps {
+  name: IconName;
+  /** Square edge length in px (defaults to a 24pt glyph). */
+  size?: number;
+  /** Fill colour — pass a theme colour from the call site. */
+  color: string;
+}
+
+/**
+ * Render a single vector glyph. The path is parsed once per name and scaled from
+ * its 24×24 authoring box to {@link size}.
+ */
+export function Icon({ name, size = 24, color }: IconProps): React.JSX.Element {
+  const path = useMemo(() => Skia.Path.MakeFromSVGString(ICON_PATHS[name]), [name]);
+  const scale = size / VIEWBOX;
+
+  if (path == null) {
+    // Defensive: an unparsable path should never blank the layout.
+    return <View style={{ width: size, height: size }} />;
+  }
+
+  return (
+    <Canvas style={{ width: size, height: size }}>
+      <Group transform={[{ scale }]}>
+        <Path path={path} color={color} style="fill" />
+      </Group>
+    </Canvas>
+  );
+}
+
+export default Icon;

--- a/packages/client/src/configs/theme.ts
+++ b/packages/client/src/configs/theme.ts
@@ -113,81 +113,89 @@ export const palettes: Record<
       }
     }
   },
-  // Dark mode palette colors
+  // Dark mode palette colors.
+  //
+  // These are true dark surfaces (not a copy of the light ramp): backgrounds
+  // collapse toward near-black while keeping the role ordering screens rely on
+  // (canvas `neutral50` is the deepest, `neutral100` cards sit above the
+  // `neutral300` screen base, `neutral500` are visible hairlines). Muted greys
+  // are lightened so secondary text stays legible, and `primary500`/`primary100`
+  // are brightened so accents and the melody contour still read on the dark
+  // Skia canvases.
   dark: {
     [ETheme.Blue]: {
       selectedPalette: ETheme.Blue,
       colors: {
         ...basicColors,
-        error: '#FF4949',
-        gold: '#8D8476',
-        typography: '#323E58',
-        gray50: '#F3F4F6',
-        gray100: '#ADB1B8',
-        gray300: '#828894',
-        gray500: '#545A63',
-        gray700: '#3E444C',
-        neutral50: '#FDFBF7',
-        neutral100: '#FBF6EE',
-        neutral300: '#F8F0E3',
-        neutral500: '#D9CEBD',
-        primary25: '#F3F8FF',
-        primary50: '#CADFFF',
-        primary100: '#A7C8FC',
+        error: '#FF6B6B',
+        gold: '#CBB98C',
+        typography: '#ECEEF2',
+        gray50: '#2A2E36',
+        gray100: '#5C626D',
+        gray300: '#9BA1AD',
+        gray500: '#B3B9C4',
+        gray700: '#D6DAE1',
+        neutral50: '#0E1116',
+        neutral100: '#1B1F27',
+        neutral300: '#13161C',
+        neutral500: '#363B46',
+        primary25: '#0F1B2E',
+        primary50: '#14294A',
+        primary100: '#5E8FD6',
         primary300: '#4F8BE6',
-        primary500: '#0F52BA',
-        primary700: '#013B95',
-        primary900: '#021A40'
+        primary500: '#3D7BE0',
+        primary700: '#7DA9EE',
+        primary900: '#C3D9F8'
       }
     },
     [ETheme.Red]: {
       selectedPalette: ETheme.Red,
       colors: {
         ...basicColors,
-        error: '#D43939',
-        gold: '#8D7E76',
-        typography: '#29121B',
-        gray50: '#F6F5F5',
-        gray100: '#B8ADB1',
-        gray300: '#948289',
-        gray500: '#63545A',
-        gray700: '#3D3135',
-        neutral50: '#FDFBFA',
-        neutral100: '#FBF5F2',
-        neutral300: '#F9F0EC',
-        neutral500: '#D9C7BD',
-        primary25: '#FBF4F6',
-        primary50: '#FFEAF2',
-        primary100: '#F7BFD4',
+        error: '#FF6B6B',
+        gold: '#CBB08C',
+        typography: '#F3EAEE',
+        gray50: '#322A2E',
+        gray100: '#6D5C62',
+        gray300: '#AD9BA2',
+        gray500: '#C4B3B9',
+        gray700: '#E1D6DA',
+        neutral50: '#140E11',
+        neutral100: '#241B1F',
+        neutral300: '#1A1316',
+        neutral500: '#46363B',
+        primary25: '#2E0F1B',
+        primary50: '#4A1429',
+        primary100: '#E68AAE',
         primary300: '#F3639E',
-        primary500: '#E0115F',
-        primary700: '#850837',
-        primary900: '#2F0213'
+        primary500: '#EC3F76',
+        primary700: '#F78CB1',
+        primary900: '#FBC9D9'
       }
     },
     [ETheme.Green]: {
       selectedPalette: ETheme.Green,
       colors: {
         ...basicColors,
-        error: '#FF4949',
-        gold: '#8D7A76',
-        typography: '#384343',
-        gray50: '#F3FFFF',
-        gray100: '#C4C8C8',
-        gray300: '#889090',
-        gray500: '#546363',
-        gray700: '#313D3D',
-        neutral50: '#FDFBFB',
-        neutral100: '#FEFEFE',
-        neutral300: '#FBF9F8',
-        neutral500: '#E5D6D3',
-        primary25: '#F3FFFF',
-        primary50: '#DDFCFC',
-        primary100: '#BAF6F6',
+        error: '#FF6B6B',
+        gold: '#BFC79C',
+        typography: '#E9F0EE',
+        gray50: '#2A322F',
+        gray100: '#5C6D67',
+        gray300: '#9BADA7',
+        gray500: '#B3C4BE',
+        gray700: '#D6E1DD',
+        neutral50: '#0C1212',
+        neutral100: '#18211F',
+        neutral300: '#101715',
+        neutral500: '#34433F',
+        primary25: '#0E2929',
+        primary50: '#134A4A',
+        primary100: '#5FD0D0',
         primary300: '#45DFDF',
-        primary500: '#008080',
-        primary700: '#085555',
-        primary900: '#032929'
+        primary500: '#13A3A3',
+        primary700: '#7DEEEE',
+        primary900: '#C3F7F7'
       }
     }
   }

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -48,7 +48,9 @@
   },
   "results": {
     "title": "Results",
+    "take": "Take",
     "notes": "Notes",
+    "notesSection": "Notes (tap to hear)",
     "noReferenceMelody": "No reference melody",
     "inTune": "In tune",
     "length": "Length",
@@ -56,7 +58,21 @@
     "exportMidi": "Export MIDI",
     "preparingMidi": "Preparing MIDI…",
     "shareError": "Couldn't share the file. Try again.",
-    "outOf100": "/ 100"
+    "outOf100": "/ 100",
+    "scoreAccessibility": "Pitch score {{score}} out of 100",
+    "feedbackLabel": "Take feedback",
+    "key": "Key",
+    "tempo": "Tempo",
+    "bpm": "{{value}} BPM",
+    "strengths": "Strengths",
+    "improvements": "To improve",
+    "suggestions": "Try this",
+    "noteRow": "Note {{index}}: {{name}}, {{ms}} milliseconds, {{cents}} cents",
+    "noteRowTappable": "Note {{index}}: {{name}}, {{ms}} milliseconds, {{cents}} cents, tap to hear"
+  },
+  "errorScreen": {
+    "title": "Something went wrong",
+    "body": "The app ran into an unexpected problem. You can try again."
   },
   "notes": {
     "title": "Notes",
@@ -75,6 +91,12 @@
     "deleteNote": "Delete note",
     "notesTapToHear": "Notes (tap to hear)",
     "notFound": "Note not found.",
+    "delete": {
+      "confirmTitle": "Delete note?",
+      "confirmBody": "“{{title}}” will be permanently deleted. This can't be undone.",
+      "confirm": "Delete",
+      "cancel": "Cancel"
+    },
     "stat": {
       "key": "Key",
       "tempo": "Tempo",
@@ -129,8 +151,7 @@
   },
   "account": {
     "title": "Account & Settings",
-    "open": "Open account and settings",
-    "headerIcon": "⚙︎"
+    "open": "Open account and settings"
   },
   "profile": {
     "title": "Profile",

--- a/packages/client/src/navigation/RootNavigator.tsx
+++ b/packages/client/src/navigation/RootNavigator.tsx
@@ -5,11 +5,13 @@ import {
 } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import React, { useCallback } from 'react';
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 
 import { useAuth } from '../auth';
 import { useTheme } from '../theme';
 import { useTranslation } from '../i18n';
+import { Icon, type IconName } from '../components/Icon';
+import Splash from '../screens/Splash';
 import AccountScreen from '../screens/Account/AccountScreen';
 import DashboardScreen from '../screens/Dashboard/DashboardScreen';
 import LoginScreen from '../screens/Login/LoginScreen';
@@ -46,19 +48,24 @@ function AccountHeaderButton() {
       accessibilityLabel={t('account.open')}
       style={styles.headerButton}
     >
-      <Text style={[styles.headerButtonText, { color: colors.primary500 }]}>
-        {t('account.headerIcon')}
-      </Text>
+      <Icon name="settings" size={24} color={colors.primary500} />
     </Pressable>
   );
 }
+
+/** Tab id → glyph for the bottom tab bar. */
+const TAB_ICONS: Record<keyof MainTabParamList, IconName> = {
+  Practice: 'practice',
+  Notes: 'notes',
+  Dashboard: 'dashboard'
+};
 
 function MainTabs() {
   const { colors } = useTheme();
   const { t } = useTranslation();
   return (
     <Tab.Navigator
-      screenOptions={{
+      screenOptions={({ route }) => ({
         headerShown: true,
         headerStyle: { backgroundColor: colors.neutral300 },
         headerTitleStyle: { color: colors.typography },
@@ -66,8 +73,11 @@ function MainTabs() {
         headerRight: () => <AccountHeaderButton />,
         tabBarActiveTintColor: colors.primary500,
         tabBarInactiveTintColor: colors.gray300,
-        tabBarStyle: { backgroundColor: colors.neutral100 }
-      }}
+        tabBarStyle: { backgroundColor: colors.neutral100 },
+        tabBarIcon: ({ color, size }) => (
+          <Icon name={TAB_ICONS[route.name]} size={size} color={color} />
+        )
+      })}
     >
       <Tab.Screen
         name="Practice"
@@ -93,7 +103,8 @@ export default function RootNavigator() {
   const { t } = useTranslation();
 
   if (loading) {
-    return null; // initial session restore; a splash can replace this later
+    // Initial session restore: show the branded splash instead of a blank frame.
+    return <Splash />;
   }
 
   return (
@@ -139,6 +150,5 @@ export default function RootNavigator() {
 }
 
 const styles = StyleSheet.create({
-  headerButton: { paddingHorizontal: 16 },
-  headerButtonText: { fontSize: 20 }
+  headerButton: { paddingHorizontal: 16 }
 });

--- a/packages/client/src/screens/ErrorBoundary.tsx
+++ b/packages/client/src/screens/ErrorBoundary.tsx
@@ -1,6 +1,33 @@
-import React, { PureComponent, ReactElement } from 'react';
-import { Text, View } from 'react-native';
+/**
+ * ErrorBoundary — last-resort recovery surface.
+ *
+ * Catches render-time crashes anywhere below it and shows a themed, localized
+ * fallback with a "Try again" action that clears the error and re-mounts the
+ * subtree (rather than stranding the user on a blank white screen). The visual
+ * fallback is a function component so it can read theme + i18n via hooks; the
+ * boundary itself must stay a class to use the error lifecycle.
+ *
+ * Mounted inside the app providers so the fallback has theme and translation
+ * context available.
+ */
+import React, { PureComponent, useContext, type ReactElement } from 'react';
+import { SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
 import AppError from '../utilities/errors';
+import { ThemeContext } from '../theme';
+import { useTranslation } from '../i18n';
+
+/**
+ * Minimal colours used if the boundary renders without a ThemeProvider above it
+ * (e.g. a provider itself threw). Keeps the recovery screen legible regardless.
+ */
+const FALLBACK_COLORS = {
+  neutral300: '#13161C',
+  typography: '#ECEEF2',
+  gray300: '#9BA1AD',
+  primary500: '#3D7BE0',
+  white: '#FFFFFF'
+};
 
 interface ErrorBoundaryProps {
   children: ReactElement;
@@ -10,7 +37,39 @@ interface State {
   error: AppError | undefined;
 }
 
-export default class ErrorBoundary extends PureComponent<ErrorBoundaryProps> {
+/** Themed, localized fallback UI shown when the boundary has caught an error. */
+function ErrorFallback({ onRetry }: { onRetry: () => void }): React.JSX.Element {
+  const theme = useContext(ThemeContext);
+  const colors = theme?.colors ?? FALLBACK_COLORS;
+  const { t } = useTranslation();
+  return (
+    <SafeAreaView style={[styles.safe, { backgroundColor: colors.neutral300 }]}>
+      <View style={styles.center}>
+        <Text style={[styles.title, { color: colors.typography }]}>
+          {t('errorScreen.title')}
+        </Text>
+        <Text style={[styles.body, { color: colors.gray300 }]}>
+          {t('errorScreen.body')}
+        </Text>
+        <TouchableOpacity
+          style={[styles.button, { backgroundColor: colors.primary500 }]}
+          onPress={onRetry}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.retry')}
+        >
+          <Text style={[styles.buttonText, { color: colors.white }]}>
+            {t('common.retry')}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export default class ErrorBoundary extends PureComponent<
+  ErrorBoundaryProps,
+  State
+> {
   state: State = {
     error: undefined
   };
@@ -21,29 +80,42 @@ export default class ErrorBoundary extends PureComponent<ErrorBoundaryProps> {
     };
   }
 
-  /**
-   * @param error - unknown error type
-   * @param errorInfo - { componentStack }: ErrorInfo
-   * */
   async componentDidCatch() {
     // const appError = new AppError(error, { stack: componentStack });
     // Send to log endpoint
   }
 
-  restartApp() {
-    // Possibly deal with user credentials before restarting?
-    // RNRestart.Restart();
-  }
+  /** Clear the caught error so the children re-mount and the app recovers. */
+  handleRetry = (): void => {
+    this.setState({ error: undefined });
+  };
 
   render() {
     if (this.state.error) {
-      return (
-        <View>
-          <Text>An Error has occurred</Text>
-        </View>
-      );
-    } else {
-      return this.props.children;
+      return <ErrorFallback onRetry={this.handleRetry} />;
     }
+    return this.props.children;
   }
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    gap: 12
+  },
+  title: { fontSize: 20, fontWeight: '700', textAlign: 'center' },
+  body: { fontSize: 14, textAlign: 'center', lineHeight: 20 },
+  button: {
+    height: 48,
+    borderRadius: 12,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12
+  },
+  buttonText: { fontSize: 16, fontWeight: '700' }
+});

--- a/packages/client/src/screens/Notes/NoteCard.tsx
+++ b/packages/client/src/screens/Notes/NoteCard.tsx
@@ -181,7 +181,7 @@ export function NoteCard({ note, onOpen, onDelete }: NoteCardProps) {
           accessibilityRole="button"
           accessibilityLabel={t('notes.deleteNote')}
           onPress={handleDelete}
-          style={[styles.actionButton, { backgroundColor: colors.neutral300 }]}
+          style={[styles.actionButton, styles.deleteButton]}
         >
           <Text style={[styles.actionLabel, { color: colors.error }]}>
             {t('common.delete')}
@@ -216,6 +216,7 @@ const styles = StyleSheet.create({
   playbackWrap: { paddingVertical: 4 },
   actions: {
     flexDirection: 'row',
+    alignItems: 'center',
     gap: 8,
     marginTop: 4
   },
@@ -225,6 +226,12 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
     justifyContent: 'center'
+  },
+  // Tertiary, destructive: pushed to the end with no fill so it doesn't read as
+  // a peer of the primary Play / Analysis actions.
+  deleteButton: {
+    marginLeft: 'auto',
+    backgroundColor: 'transparent'
   },
   actionLabel: {
     fontSize: 13,

--- a/packages/client/src/screens/Notes/NotesScreen.tsx
+++ b/packages/client/src/screens/Notes/NotesScreen.tsx
@@ -11,6 +11,7 @@
 import React, { useCallback } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
   RefreshControl,
   SafeAreaView,
@@ -75,11 +76,25 @@ export function NotesScreen(): React.JSX.Element {
     [navigation]
   );
 
+  // Deleting a note destroys real captured audio with no undo, so confirm first
+  // (mirrors the account-deletion guard in AccountScreen).
   const handleRemove = useCallback(
     (id: string): void => {
-      void remove(id);
+      const note = notes.find((n) => n.id === id);
+      Alert.alert(
+        t('notes.delete.confirmTitle'),
+        t('notes.delete.confirmBody', { title: note?.title ?? '' }),
+        [
+          { text: t('notes.delete.cancel'), style: 'cancel' },
+          {
+            text: t('notes.delete.confirm'),
+            style: 'destructive',
+            onPress: () => void remove(id)
+          }
+        ]
+      );
     },
-    [remove]
+    [notes, remove, t]
   );
 
   const renderItem = useCallback(

--- a/packages/client/src/screens/Results/ExportSheet.tsx
+++ b/packages/client/src/screens/Results/ExportSheet.tsx
@@ -17,6 +17,7 @@ import {
 import Share from 'react-native-share';
 
 import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
 
 export interface ExportSheetProps {
   /** `file://` URI of the exported `.mid`, or null until it has been written. */
@@ -29,6 +30,7 @@ type ShareStatus = 'idle' | 'sharing' | 'error';
 
 export function ExportSheet({ midiUri, title }: ExportSheetProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const [status, setStatus] = useState<ShareStatus>('idle');
 
   const onShare = useCallback(async () => {
@@ -59,7 +61,7 @@ export function ExportSheet({ midiUri, title }: ExportSheetProps) {
       <Pressable
         accessibilityRole="button"
         accessibilityState={{ disabled }}
-        accessibilityLabel="Export MIDI"
+        accessibilityLabel={t('results.exportMidi')}
         disabled={disabled}
         onPress={onShare}
         style={[
@@ -72,16 +74,20 @@ export function ExportSheet({ midiUri, title }: ExportSheetProps) {
         {status === 'sharing' ? (
           <ActivityIndicator color={colors.white} />
         ) : (
-          <Text style={[styles.buttonText, { color: colors.white }]}>Export MIDI</Text>
+          <Text style={[styles.buttonText, { color: colors.white }]}>
+            {t('results.exportMidi')}
+          </Text>
         )}
       </Pressable>
 
       {midiUri == null ? (
-        <Text style={[styles.hint, { color: colors.gray300 }]}>Preparing MIDI…</Text>
+        <Text style={[styles.hint, { color: colors.gray300 }]}>
+          {t('results.preparingMidi')}
+        </Text>
       ) : null}
       {status === 'error' ? (
         <Text style={[styles.hint, { color: colors.error }]}>
-          Couldn’t share the file. Try again.
+          {t('results.shareError')}
         </Text>
       ) : null}
     </View>

--- a/packages/client/src/screens/Results/FeedbackCard.tsx
+++ b/packages/client/src/screens/Results/FeedbackCard.tsx
@@ -13,6 +13,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import type { FeedbackDto } from 'shared';
 
 import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
 
 export interface FeedbackCardProps {
   /** On-device feedback for the take. */
@@ -55,6 +56,7 @@ function Section(props: {
 
 export function FeedbackCard({ feedback }: FeedbackCardProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <View
@@ -63,39 +65,43 @@ export function FeedbackCard({ feedback }: FeedbackCardProps) {
         { backgroundColor: colors.neutral100, borderColor: colors.neutral500 }
       ]}
       accessibilityRole="summary"
-      accessibilityLabel="Take feedback"
+      accessibilityLabel={t('results.feedbackLabel')}
     >
       <View style={styles.chips}>
         <Chip
-          label="Key"
+          label={t('results.key')}
           value={feedback.key ?? '—'}
           color={colors.typography}
           muted={colors.gray300}
         />
         <Chip
-          label="Tempo"
-          value={feedback.tempoBpm != null ? `${feedback.tempoBpm} BPM` : '—'}
+          label={t('results.tempo')}
+          value={
+            feedback.tempoBpm != null
+              ? t('results.bpm', { value: feedback.tempoBpm })
+              : '—'
+          }
           color={colors.typography}
           muted={colors.gray300}
         />
       </View>
 
       <Section
-        title="Strengths"
+        title={t('results.strengths')}
         items={feedback.strengths}
         bullet="+"
         titleColor={colors.primary500}
         textColor={colors.typography}
       />
       <Section
-        title="To improve"
+        title={t('results.improvements')}
         items={feedback.improvements}
         bullet="!"
         titleColor={colors.gray500}
         textColor={colors.typography}
       />
       <Section
-        title="Try this"
+        title={t('results.suggestions')}
         items={feedback.suggestions}
         bullet="→"
         titleColor={colors.gray500}

--- a/packages/client/src/screens/Results/NoteList.tsx
+++ b/packages/client/src/screens/Results/NoteList.tsx
@@ -18,6 +18,7 @@ import {
 import { NOTE_NAMES, type NoteEvent } from 'logic';
 
 import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
 
 export interface NoteListProps {
   notes: NoteEvent[];
@@ -38,15 +39,22 @@ function formatTime(ms: number): string {
 
 export function NoteList({ notes, onPressNote }: NoteListProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<NoteEvent>) => {
       const cents = Math.round(item.cents);
       const centsLabel = cents === 0 ? '±0' : cents > 0 ? `+${cents}` : `${cents}`;
       const tappable = onPressNote != null;
-      const label = `Note ${index + 1}: ${midiToLabel(item.midi)}, ${Math.round(
-        item.durationMs
-      )} milliseconds, ${centsLabel} cents${tappable ? ', tap to hear' : ''}`;
+      const label = t(
+        tappable ? 'results.noteRowTappable' : 'results.noteRow',
+        {
+          index: index + 1,
+          name: midiToLabel(item.midi),
+          ms: Math.round(item.durationMs),
+          cents: centsLabel
+        }
+      );
       const cells = (
         <>
           <Text style={[styles.name, { color: colors.typography }]}>
@@ -84,14 +92,14 @@ export function NoteList({ notes, onPressNote }: NoteListProps) {
         </View>
       );
     },
-    [colors, onPressNote]
+    [colors, onPressNote, t]
   );
 
   if (notes.length === 0) {
     return (
       <View style={styles.empty}>
         <Text style={[styles.emptyText, { color: colors.gray300 }]}>
-          No notes detected in this take.
+          {t('results.noNotes')}
         </Text>
       </View>
     );

--- a/packages/client/src/screens/Results/ResultsScreen.tsx
+++ b/packages/client/src/screens/Results/ResultsScreen.tsx
@@ -17,6 +17,7 @@ import { findMelody, type TargetNote } from 'logic';
 
 import type { RootStackParamList } from '../../navigation/types';
 import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
 import { createReferenceTonePlayer } from '../../audio/referenceTone';
 import { ExportSheet } from './ExportSheet';
 import { FeedbackCard } from './FeedbackCard';
@@ -31,6 +32,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Results'>;
 
 export default function ResultsScreen({ route }: Props) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
   const { handle, practice } = route.params;
 
   // For a practice take, rebuild the reference melody so scoring + per-note
@@ -50,7 +52,7 @@ export default function ResultsScreen({ route }: Props) {
     targets,
     practice
   });
-  const title = melody?.name ?? 'Take';
+  const title = melody?.name ?? t('results.take');
 
   // Tap a note to hear its true pitch (reuses the practice reference-tone player).
   const tonePlayer = useMemo(() => createReferenceTonePlayer(), []);
@@ -65,7 +67,9 @@ export default function ResultsScreen({ route }: Props) {
   return (
     <SafeAreaView style={[styles.safe, { backgroundColor: colors.neutral300 }]}>
       <View style={styles.content}>
-        <Text style={[styles.heading, { color: colors.typography }]}>Results</Text>
+        <Text style={[styles.heading, { color: colors.typography }]}>
+          {t('results.title')}
+        </Text>
 
         <ScoreCard
           noteCount={notes.length}
@@ -77,7 +81,7 @@ export default function ResultsScreen({ route }: Props) {
 
         <View style={styles.listWrap}>
           <Text style={[styles.sectionTitle, { color: colors.gray500 }]}>
-            Notes (tap to hear)
+            {t('results.notesSection')}
           </Text>
           <NoteList notes={notes} onPressNote={playNote} />
         </View>

--- a/packages/client/src/screens/Results/ScoreCard.tsx
+++ b/packages/client/src/screens/Results/ScoreCard.tsx
@@ -11,6 +11,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import type { PitchScore } from 'logic';
 
 import { useTheme } from '../../theme';
+import { useTranslation } from '../../i18n';
 
 export interface ScoreCardProps {
   /** Number of segmented notes in the take. */
@@ -44,6 +45,7 @@ function Stat(props: {
 
 export function ScoreCard({ noteCount, durationMs, score }: ScoreCardProps) {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <View
@@ -57,32 +59,38 @@ export function ScoreCard({ noteCount, durationMs, score }: ScoreCardProps) {
         <View style={styles.scoreBlock}>
           <Text
             style={[styles.score, { color: colors.primary500 }]}
-            accessibilityLabel={`Pitch score ${score.score} out of 100`}
+            accessibilityLabel={t('results.scoreAccessibility', {
+              score: score.score
+            })}
           >
             {score.score}
           </Text>
-          <Text style={[styles.scoreUnit, { color: colors.gray300 }]}>/ 100</Text>
+          <Text style={[styles.scoreUnit, { color: colors.gray300 }]}>
+            {t('results.outOf100')}
+          </Text>
         </View>
       ) : (
-        <Text style={[styles.noScore, { color: colors.gray300 }]}>No reference melody</Text>
+        <Text style={[styles.noScore, { color: colors.gray300 }]}>
+          {t('results.noReferenceMelody')}
+        </Text>
       )}
 
       <View style={styles.row}>
         <Stat
-          label="Notes"
+          label={t('results.notes')}
           value={String(noteCount)}
           color={colors.typography}
           muted={colors.gray300}
         />
         <Stat
-          label="Length"
+          label={t('results.length')}
           value={formatDuration(durationMs)}
           color={colors.typography}
           muted={colors.gray300}
         />
         {score != null ? (
           <Stat
-            label="In tune"
+            label={t('results.inTune')}
             value={`${Math.round(score.inTuneRatio * 100)}%`}
             color={colors.typography}
             muted={colors.gray300}

--- a/packages/client/src/screens/Splash.tsx
+++ b/packages/client/src/screens/Splash.tsx
@@ -1,6 +1,34 @@
+/**
+ * Splash — the branded launch / session-restore screen.
+ *
+ * Shown by the RootNavigator while the auth session is being restored (which was
+ * previously a blank frame). The mark is a Skia vector glyph, so the splash is
+ * resolution-independent and ships over-the-air with the JS bundle — no native
+ * launch-image asset to rebuild.
+ */
 import React from 'react';
-import { View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
-export default function Splash() {
-  return <View></View>;
+import { useTheme } from '../theme';
+import { Icon } from '../components/Icon';
+
+export default function Splash(): React.JSX.Element {
+  const { colors } = useTheme();
+  return (
+    <SafeAreaView style={[styles.safe, { backgroundColor: colors.neutral300 }]}>
+      <View style={styles.center}>
+        <Icon name="mic" size={72} color={colors.primary500} />
+        <Text style={[styles.wordmark, { color: colors.typography }]}>micdrp</Text>
+        <ActivityIndicator color={colors.primary500} style={styles.spinner} />
+      </View>
+    </SafeAreaView>
+  );
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 },
+  wordmark: { fontSize: 32, fontWeight: '700', letterSpacing: 1 },
+  spinner: { marginTop: 16 }
+});

--- a/packages/client/src/screens/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/packages/client/src/screens/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -5,11 +5,3 @@ exports[`ErrorBoundary component renders children properly when no error is thro
   testID="child"
 />
 `;
-
-exports[`ErrorBoundary component renders when an uncaught error is thrown from within a child component 1`] = `
-<View>
-  <Text>
-    An Error has occurred
-  </Text>
-</View>
-`;

--- a/packages/client/src/theme/ThemeProvider.tsx
+++ b/packages/client/src/theme/ThemeProvider.tsx
@@ -30,7 +30,12 @@ export interface ThemeValue {
   setPalette(palette: ETheme): void;
 }
 
-const ThemeContext = createContext<ThemeValue | undefined>(undefined);
+/**
+ * Exported so resilient consumers (e.g. the top-level ErrorBoundary, which may
+ * render after a provider has unmounted) can read the theme via `useContext`
+ * with their own fallback instead of throwing through {@link useTheme}.
+ */
+export const ThemeContext = createContext<ThemeValue | undefined>(undefined);
 
 interface ThemeProviderProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary

Implements the high- and medium-priority findings from a UX audit of the client app. Per request, **all new visuals are Skia vector paths (SVG path data) — no native assets**, so every change is shippable over-the-air with the JS bundle.

## What changed

### 🔴 Dark mode now actually works
The `dark` palette in `configs/theme.ts` was a **byte-for-byte copy of the light ramp**, so the system dark setting did nothing — users got the cream light theme at night. Replaced it with real dark surfaces for all three themes (Blue/Red/Green): backgrounds collapse toward near-black while keeping the role ordering screens rely on (canvas `neutral50` deepest, `neutral100` cards above the `neutral300` screen base, `neutral500` visible hairlines). Muted greys are lightened for legibility and `primary500`/`primary100` brightened so accents and the melody contour still read on the dark Skia canvases.

### 🔴 Results flow is now localized
`ResultsScreen`, `ScoreCard`, `FeedbackCard`, `ExportSheet`, and `NoteList` hardcoded English (`"Results"`, `"Export MIDI"`, `"Strengths"`, `"In tune"`, row a11y labels, …) while the rest of the app used `t()`. All now go through i18n. Most keys already existed under `results.*`; added the missing ones plus `errorScreen.*` and `notes.delete.*`.

### 🔴 Note deletion is no longer a one-tap data loss
Deleting a note destroyed real captured audio immediately with no undo. Now guarded behind a confirmation dialog (mirroring the existing account-deletion guard), and the Delete control is de-emphasized (tertiary, no fill, pushed to the end) so it doesn't read as a peer of Play/Analysis.

### 🟠 Branded splash instead of a blank frame
`Splash` was an empty `<View>` that was never mounted; the navigator returned `null` during session restore. Splash is now a themed screen (Skia mic mark + wordmark + spinner) rendered during the auth check.

### 🟠 Recoverable error boundary, and it's actually mounted
`ErrorBoundary` was an unstyled, un-localized dead-end (`"An Error has occurred"`) that was never wired into the tree. It's now themed, localized, has a working **Try again** action that clears the error and re-mounts the subtree, and is mounted in `App.tsx` inside the providers. It reads the theme via context with a safe fallback so it survives even a broken provider.

### 🟠 Tab icons + real settings glyph
Added a Skia `Icon` component (24×24 SVG path data) and wired bottom-tab icons (mic / note / bars) plus a proper settings cog in the header, replacing the fragile `"⚙︎"` text glyph.

## Testing notes

I could not run the suite in this environment — workspace deps aren't installed and the sandbox proxy blocks the Yarn 3 download. CI runs only the `logic` + `shared` suites (the client RN suite needs native deps), so these changes aren't exercised there. To keep the **client** suite green locally I:
- added `Skia.Path.MakeFromSVGString` to the jest Skia mock (used by the new `Icon` and the existing `TrendChart`),
- exported `ThemeContext` so the error fallback can render without a provider in tests,
- removed the stale `ErrorBoundary` error-case snapshot so it regenerates.

Please run `yarn test client`, `yarn typecheck`, and `yarn lint` to confirm before merge.

## Out of scope (noted in the audit, not addressed here)
- Custom fonts (`GillSans`/`Futura-Bold`) don't exist on Android → silent fallback.
- i18n still ships only `en` (infra is real; no second locale).
- A couple of Login inline error strings remain unlocalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBKKoyLZnUv3vsHRCcRr4)_